### PR TITLE
Remove H100 check in fake test

### DIFF
--- a/tests/fake/test_fake.py
+++ b/tests/fake/test_fake.py
@@ -32,4 +32,3 @@ class FakeTestCase(unittest.TestCase):
         """Test nvidia-smi."""
         smi = os.popen('nvidia-smi').read().strip()
         self.assertIn('NVIDIA-SMI', smi)
-        self.assertIn('H100', smi)


### PR DESCRIPTION
**Description**
MS-AMP also supports non-H100 GPUs. We can remove this unit-test.

**Minor Revision**
- Remove H100 check in fake test
