### PR TITLE
Add grad scaler for examples

### DIFF
--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -61,14 +61,16 @@ def train(args, model, device, train_loader, optimizer, epoch):
         optimizer (torch.optim.Optimizer): the optimizer to use.
         epoch (int): the number of epoch to run on data loader.
     """
+    scaler = torch.cuda.amp.GradScaler()
     model.train()
     for batch_idx, (data, target) in enumerate(train_loader):
         data, target = data.to(device), target.to(device)
         optimizer.zero_grad()
-        output = model(data)
+        with torch.cuda.amp.autocast():
+            output = model(data)
         loss = F.nll_loss(output, target)
-        loss.backward()
-        optimizer.step()
+        scaler.scale(loss).backward()
+        scaler.step(optimizer)
         if batch_idx % args.log_interval == 0:
             print(
                 'Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
@@ -94,7 +96,8 @@ def test(model, device, test_loader):
     with torch.no_grad():
         for data, target in test_loader:
             data, target = data.to(device), target.to(device)
-            output = model(data)
+            with torch.cuda.amp.autocast():
+                output = model(data)
             test_loss += F.nll_loss(output, target, reduction='sum').item()    # sum up batch loss
             pred = output.argmax(dim=1, keepdim=True)    # get the index of the max log-probability
             correct += pred.eq(target.view_as(pred)).sum().item()

--- a/examples/mnist_ddp.py
+++ b/examples/mnist_ddp.py
@@ -61,16 +61,18 @@ def train(args, model, device, train_loader, optimizer, epoch):
         optimizer (torch.optim.Optimizer): the optimizer to use.
         epoch (int): the number of epoch to run on data loader.
     """
+    scaler = torch.cuda.amp.GradScaler()
     model.train()
     for batch_idx, (data, target) in enumerate(train_loader):
         data, target = data.to(device), target.to(device)
         optimizer.zero_grad()
-        output = model(data)
+        with torch.cuda.amp.autocast():
+            output = model(data)
         loss = F.nll_loss(output, target)
-        loss.backward()
+        scaler.scale(loss).backward()
         if hasattr(optimizer, 'all_reduce_grads'):
             optimizer.all_reduce_grads(model)
-        optimizer.step()
+        scaler.step(optimizer)
         if dist.get_rank() == 0:
             if batch_idx % args.log_interval == 0:
                 print(
@@ -98,7 +100,8 @@ def test(model, device, test_loader):
     with torch.no_grad():
         for data, target in test_loader:
             data, target = data.to(device), target.to(device)
-            output = model(data)
+            with torch.cuda.amp.autocast():
+                output = model(data)
             test_loss += F.nll_loss(output, target, reduction='sum').item()    # sum up batch loss
             pred = output.argmax(dim=1, keepdim=True)    # get the index of the max log-probability
             correct += pred.eq(target.view_as(pred)).sum().item()


### PR DESCRIPTION
**Description**
Use torch.cuda.amp.GradScaler() for examples (#21)

Performance:
Before (FP32 + FP8):

Accuracy:
Method | FP32 | Mixed FP8 O2
-----------|-------|-----------------
minist.py| 98.77 | 98.79
minist_ddp.py on 8 GPUs| 98.18 | 98.16

After (FP16 + FP8)

Accuracy:
Method | FP16-AMP | Mixed FP8 O2
-----------|-------|-----------------
minist.py|  98.88 | 98.75
minist_ddp.py on 8 GPUs| 98.22 | 98.21