### PR TITLE
[Bug Fixed] add `scaler.update()` in MNIST examples

### DIFF
--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -71,6 +71,7 @@ def train(args, model, device, train_loader, optimizer, epoch):
         loss = F.nll_loss(output, target)
         scaler.scale(loss).backward()
         scaler.step(optimizer)
+        scaler.update()
         if batch_idx % args.log_interval == 0:
             print(
                 'Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(

--- a/examples/mnist_ddp.py
+++ b/examples/mnist_ddp.py
@@ -73,6 +73,7 @@ def train(args, model, device, train_loader, optimizer, epoch):
         if hasattr(optimizer, 'all_reduce_grads'):
             optimizer.all_reduce_grads(model)
         scaler.step(optimizer)
+        scaler.update()
         if dist.get_rank() == 0:
             if batch_idx % args.log_interval == 0:
                 print(


### PR DESCRIPTION
**Description**
Fix the following bug introduced in the PR #36 . The `scaler.update()` should be called after `scaler.step(optimizer)`.

```
Traceback (most recent call last):
  File "mnist.py", line 181, in <module>
    main()
  File "mnist.py", line 172, in main
    train(args, model, device, train_loader, optimizer, epoch)
  File "mnist.py", line 73, in train
    scaler.step(optimizer)
  File "/opt/conda/lib/python3.8/site-packages/torch/cuda/amp/grad_scaler.py", line 321, in step
    raise RuntimeError("step() has already been called since the last update().")
RuntimeError: step() has already been called since the last update().
```

**Major Revision**
- add `scaler.update()` after `scaler.step(optimizer)`