### PR TITLE
[Bug Fixed] update the cast of ScalingTensor-FP16

### DIFF
--- a/msamp/common/tensor/cast.py
+++ b/msamp/common/tensor/cast.py
@@ -61,10 +61,11 @@ class TypeCast:
             torch.Tensor: tensor whose dtype is torch.float16.
         """
         meta.amax[0] = input.abs().max()
-        in_time = meta.is_in_time_scaling()
-        if in_time:
-            # notice: we scale the tensor with qtype FP8-E4M3.
-            meta.reset_scaling_factor(qtype=Dtypes.kfloat8_e4m3)
+        if input.dtype == torch.float16:
+            meta.scale.fill_(1.0)
+            meta.scale_inv.fill_(1.0)
+            return input.clone()
+        meta.reset_scaling_factor()
         if sync:
             world_size = DistUtil.get_world_size()
             if world_size > 1:

--- a/msamp/common/tensor/meta.py
+++ b/msamp/common/tensor/meta.py
@@ -72,6 +72,7 @@ class ScalingMeta:
     @staticmethod
     def in_time_scaling_context(enabled):
         """A context manager to set in_time_scaling flag.
+
         Args:
             bool: in_time_scaling flag.
 

--- a/msamp/common/tensor/meta.py
+++ b/msamp/common/tensor/meta.py
@@ -69,23 +69,27 @@ class ScalingMeta:
         """
         return ScalingMeta.in_time_scaling and (self.window_size == 1 or self.is_warmup())
 
-    def in_time_scaling_context(self):
+    @staticmethod
+    def in_time_scaling_context(enabled):
         """A context manager to set in_time_scaling flag.
+        Args:
+            bool: in_time_scaling flag.
 
         Returns:
             InTimeScalingContext: A context manager to set in_time_scaling flag.
         """
         class InTimeScalingContext:
-            def __init__(self):
+            def __init__(self, enabled):
+                self.enabled = enabled
                 self.in_time_scaling = ScalingMeta.in_time_scaling
 
-            def __enter__(self, enabled):
+            def __enter__(self):
                 self.in_time_scaling = ScalingMeta.in_time_scaling
-                ScalingMeta.in_time_scaling = enabled
+                ScalingMeta.in_time_scaling = self.enabled
 
             def __exit__(self, exc_type, exc_val, exc_tb):
                 ScalingMeta.in_time_scaling = self.in_time_scaling
-        return InTimeScalingContext()
+        return InTimeScalingContext(enabled=enabled)
 
     def reset_scaling_factor(self, qtype=None):
         """Reset scaling factor.

--- a/msamp/common/tensor/meta.py
+++ b/msamp/common/tensor/meta.py
@@ -89,6 +89,7 @@ class ScalingMeta:
 
             def __exit__(self, exc_type, exc_val, exc_tb):
                 ScalingMeta.in_time_scaling = self.in_time_scaling
+
         return InTimeScalingContext(enabled=enabled)
 
     def reset_scaling_factor(self, qtype=None):

--- a/msamp/common/tensor/tensor.py
+++ b/msamp/common/tensor/tensor.py
@@ -239,14 +239,18 @@ class ScalingTensor:
         if qtype == Dtypes.kfloat8_e4m3:
             if self.meta.qtype == Dtypes.kfloat16:
                 # Scaling Float16 to Scaling FP8E4M3
+                old_amax = self.meta.amax[0]
                 meta = ScalingMeta(qtype=qtype, amax=self.meta.amax.clone(),
                                    window_size=self.meta.window_size)
                 # re-compute scaling factor
                 meta.reset_scaling_factor()
                 # unscale it since self.value has been scaled by `self.scale`
+                scale_inv = torch.reciprocal(meta.scale)
                 meta.scale.mul_(self.meta.scale_inv)
                 with ScalingMeta.in_time_scaling_context(enabled=False):
                     value = TypeCast.cast_to_fp8(self.value, meta)
+                    meta.amax[0] = old_amax
+                    meta.scale_inv.fill_(scale_inv)
                 return ScalingTensor(value, meta=meta)
         elif qtype == Dtypes.kfloat32:
             return self.float().cast(Dtypes.kfloat32)

--- a/msamp/common/tensor/tensor.py
+++ b/msamp/common/tensor/tensor.py
@@ -240,8 +240,7 @@ class ScalingTensor:
             if self.meta.qtype == Dtypes.kfloat16:
                 # Scaling Float16 to Scaling FP8E4M3
                 old_amax = self.meta.amax[0]
-                meta = ScalingMeta(qtype=qtype, amax=self.meta.amax.clone(),
-                                   window_size=self.meta.window_size)
+                meta = ScalingMeta(qtype=qtype, amax=self.meta.amax.clone(), window_size=self.meta.window_size)
                 # re-compute scaling factor
                 meta.reset_scaling_factor()
                 # unscale it since self.value has been scaled by `self.scale`

--- a/tests/common/tensor/test_tensor.py
+++ b/tests/common/tensor/test_tensor.py
@@ -138,6 +138,23 @@ class ScalingTensorTestCase(unittest.TestCase):
             scaling_tensor.cast(Dtypes.kfloat8_e5m2)
 
     @decorator.cuda_test
+    def test_tensor_cast_from_scaling_tensor(self):
+        """Test tensor cast from ScalingTensor."""
+        fp16_value = torch.tensor([1.0 / (2 ** 17)], dtype=torch.float16, device=self.device)
+        fp32_value = fp16_value.float()
+
+        # cast FP16/FP32 to ScalingTensor(FP16)
+        scaling_fp16 = fp16_value.cast(Dtypes.kfloat16)
+        scaling_fp32 = fp32_value.cast(Dtypes.kfloat16)
+
+        self.assertTrue(torch.allclose(fp32_value, scaling_fp16.float()))
+        self.assertTrue(torch.allclose(fp32_value, scaling_fp32.float()))
+
+        # cast ScalingTensor(FP16) to ScalingTensor(FP8E4M3)
+        scaling_fp8 = scaling_fp16.cast(Dtypes.kfloat8_e4m3)
+        self.assertTrue(torch.allclose(fp32_value, scaling_fp8.float()))
+
+    @decorator.cuda_test
     def test_tensor_mul(self):
         """Test mul function in ScalingTensor."""
         tensor = torch.randn(self.size, device=self.device)

--- a/tests/common/tensor/test_tensor.py
+++ b/tests/common/tensor/test_tensor.py
@@ -140,7 +140,7 @@ class ScalingTensorTestCase(unittest.TestCase):
     @decorator.cuda_test
     def test_tensor_cast_from_scaling_tensor(self):
         """Test tensor cast from ScalingTensor."""
-        fp16_value = torch.tensor([1.0 / (2 ** 17)], dtype=torch.float16, device='cuda')
+        fp16_value = torch.tensor([1.0 / (2**17)], dtype=torch.float16, device='cuda')
         fp32_value = fp16_value.float()
         for dtype in [torch.float16, torch.float32]:
             value = fp16_value.to(dtype)

--- a/tests/common/tensor/test_tensor.py
+++ b/tests/common/tensor/test_tensor.py
@@ -140,19 +140,15 @@ class ScalingTensorTestCase(unittest.TestCase):
     @decorator.cuda_test
     def test_tensor_cast_from_scaling_tensor(self):
         """Test tensor cast from ScalingTensor."""
-        fp16_value = torch.tensor([1.0 / (2 ** 17)], dtype=torch.float16, device=self.device)
+        fp16_value = torch.tensor([1.0 / (2 ** 17)], dtype=torch.float16, device='cuda')
         fp32_value = fp16_value.float()
-
-        # cast FP16/FP32 to ScalingTensor(FP16)
-        scaling_fp16 = fp16_value.cast(Dtypes.kfloat16)
-        scaling_fp32 = fp32_value.cast(Dtypes.kfloat16)
-
-        self.assertTrue(torch.allclose(fp32_value, scaling_fp16.float()))
-        self.assertTrue(torch.allclose(fp32_value, scaling_fp32.float()))
-
-        # cast ScalingTensor(FP16) to ScalingTensor(FP8E4M3)
-        scaling_fp8 = scaling_fp16.cast(Dtypes.kfloat8_e4m3)
-        self.assertTrue(torch.allclose(fp32_value, scaling_fp8.float()))
+        for dtype in [torch.float16, torch.float32]:
+            value = fp16_value.to(dtype)
+            scaling_fp16 = value.cast(Dtypes.kfloat16)
+            self.assertTrue(torch.allclose(fp32_value, scaling_fp16.float()))
+            # cast ScalingTensor (FP16) to ScalingTensor (FP8E4M3)
+            scaling_fp8 = scaling_fp16.cast(Dtypes.kfloat8_e4m3)
+            self.assertTrue(torch.allclose(fp32_value, scaling_fp8.float()))
 
     @decorator.cuda_test
     def test_tensor_mul(self):


### PR DESCRIPTION
**Description**
In the function `cast_to_fp16`, [`input_fp16 = (input * meta.scale).to(torch.float16)`](https://github.com/Azure/MS-AMP/blob/main/msamp/common/tensor/cast.py#L74), if the FP32 scalar `meta.scale` is large than 65504, i.e. the maximum value of FP16, `meta.scale` will be casted to the overflow value, INF by mistake. (Please refer to the PyTorch issue: https://github.com/pytorch/pytorch/issues/98691). It leads to a wrong output.

**Reproduce**
```python
import torch
from msamp.common.tensor import tensor
from msamp.common.dtype import Dtypes

fp16_value = torch.tensor([1.0 / (2 ** 17)], dtype=torch.float16, device='cuda')
fp32_value = fp16_value.float()
for dtype in [torch.float16, torch.float32]:
    print(dtype)
    value = fp16_value.to(dtype)
    scaling_fp16 = value.cast(Dtypes.kfloat16)
    print(torch.allclose(fp32_value, scaling_fp16.float()))
    scaling_fp8 = scaling_fp16.cast(Dtypes.kfloat8_e4m3)
    print(torch.allclose(fp32_value, scaling_fp8.float()))
    print(fp32_value.float().item(), scaling_fp16.float().item(), scaling_fp8.float().item())
```

Output before Bug Fixed:
```
torch.float16
False
False
7.62939453125e-06 inf 1.3351438610698096e-05
torch.float32
True
True
7.62939453125e-06 7.629393621755298e-06 7.629393621755298e-06
```

Output after Bug Fixed: 
```
torch.float16
True
True
7.62939453125e-06 7.62939453125e-06 7.629393621755298e-06
torch.float32
True
True
7.62939453125e-06 7.629395440744702e-06 7.629393621755298e-06
```

**Major Revision**
- re-write the function `cast_to_fp16`
- Add ScalingMeta.in_time_scaling_context 
- Unit-test

**Minor Revision**
In ScalingMeta, specific FP32 dtype for amax, scale, scale_inv