### PR TITLE
[Bug Fixed] Check NAN weight gradient in mixed precision training

### DIFF
--- a/msamp/common/tensor/cast.py
+++ b/msamp/common/tensor/cast.py
@@ -6,7 +6,7 @@
 import torch
 import torch.distributed as dist
 
-from msamp.common.dtype import Dtypes
+from msamp.common.dtype import Dtypes, Floating
 from msamp.common.utils import DistUtil
 from msamp.common.utils import TransformerEngineWrapper
 
@@ -69,6 +69,7 @@ class TypeCast:
             world_size = DistUtil.get_world_size()
             if world_size > 1:
                 dist.all_reduce(meta.scale, op=dist.ReduceOp.MIN)
+        meta.scale.clamp_(max=Floating.qfp_max[meta.qtype])
 
         meta.scale_inv.data.copy_(torch.reciprocal(meta.scale))    # scale_inv = 1 / scale
         input_fp16 = (input * meta.scale).to(torch.float16)


### PR DESCRIPTION
**Description**
In mixed precision training, the function `_amp_foreach_non_finite_check_and_unscale_` needs to check whether INF or NAN exists in weight gradient. The previous code does not check NAN weight gradient. It leads ~1% accuracy drop when training DeiT-S. In this PR, I add the FP8 NAN weight gradient check.

**Major Revision**
- Update `_amp_foreach_non_finite_check_and_unscale_` to check FP8 NAN weight gradient.
- Update `ScalingTensor.isnan`
- Fix the bug in `cast_to_fp16` when scaling factor is larger than the maximal FP16 value.