### PR TITLE
[BUG Fixed] fix dist_op building when using PyTorch 2.0

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,8 +20,8 @@ jobs:
         - torch: "1.14"
           nvcr: 22.12-py3
         # 2.0.0a0+1767026
-        #- torch: "2.0"
-        #  nvcr: 23.03-py3
+        - torch: "2.0"
+          nvcr: 23.03-py3
     container:
       image: nvcr.io/nvidia/pytorch:${{ matrix.nvcr }}
       options: --privileged --ipc=host --gpus=all

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,8 +20,8 @@ jobs:
         - torch: "1.14"
           nvcr: 22.12-py3
         # 2.0.0a0+1767026
-        - torch: "2.0"
-          nvcr: 23.03-py3
+        #- torch: "2.0"
+        #  nvcr: 23.03-py3
     container:
       image: nvcr.io/nvidia/pytorch:${{ matrix.nvcr }}
       options: --privileged --ipc=host --gpus=all

--- a/msamp/operators/dist_op/dist.cpp
+++ b/msamp/operators/dist_op/dist.cpp
@@ -150,8 +150,8 @@ ncclCommPtr get_communicator(ncclUniqueId uid, int rank, int world_size) {
     return comm;
 }
 
-void dist_reduce(const at::Tensor &input, at::Tensor &output, int32_t root, int32_t op, const ncclCommPtr &user_comm,
-                 int nccl_type = -1) {
+void custom_reduce(const at::Tensor &input, at::Tensor &output, int32_t root, int32_t op,
+                   const ncclCommPtr &user_comm, int nccl_type = -1) {
     ncclDataType_t data_type = nccl_type == -1 ? to_nccl_data_type(input) : (ncclDataType_t)nccl_type;
 
     const auto count = input.numel();
@@ -167,9 +167,8 @@ void dist_reduce(const at::Tensor &input, at::Tensor &output, int32_t root, int3
                           to_nccl_comm(comm), stream));
 }
 
-void dist_all_reduce(const std::vector<at::Tensor> &inputs, std::vector<at::Tensor> &outputs,
-                     int32_t op,
-                     const std::vector<ncclCommPtr> &user_comms, int nccl_type = -1) {
+void custom_all_reduce(const std::vector<at::Tensor> &inputs, std::vector<at::Tensor> &outputs,
+                       int32_t op, const std::vector<ncclCommPtr> &user_comms, int nccl_type = -1) {
     const auto len = inputs.size();
 
     ncclDataType_t data_type = nccl_type == -1 ? to_nccl_data_type(inputs[0]) : (ncclDataType_t)nccl_type;
@@ -205,8 +204,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                 return id;
             }));
     py::class_<ncclCommPtr>(m, "ncclCommPtr").def(py::init<>());
-    m.def("reduce", &dist_reduce, "Reduce");
-    m.def("all_reduce", &dist_all_reduce, "All reduce");
+    m.def("reduce", &custom_reduce, "Reduce");
+    m.def("all_reduce", &custom_all_reduce, "All reduce");
     m.def("get_nccl_uid", &get_nccl_uid, "Get NCCL UID");
     m.def("get_communicator", &get_communicator, "Get communicator");
 }

--- a/msamp/operators/dist_op/dist.cpp
+++ b/msamp/operators/dist_op/dist.cpp
@@ -152,7 +152,7 @@ ncclCommPtr get_communicator(ncclUniqueId uid, int rank, int world_size) {
     return comm;
 }
 
-void reduce(const at::Tensor &input, at::Tensor &output, int32_t root, int32_t op, const ncclCommPtr &user_comm,
+void dist_reduce(const at::Tensor &input, at::Tensor &output, int32_t root, int32_t op, const ncclCommPtr &user_comm,
             int nccl_type = -1) {
     ncclDataType_t data_type = nccl_type == -1 ? to_nccl_data_type(input) : (ncclDataType_t)nccl_type;
 
@@ -169,7 +169,7 @@ void reduce(const at::Tensor &input, at::Tensor &output, int32_t root, int32_t o
                           to_nccl_comm(comm), stream));
 }
 
-void all_reduce(const vector<Tensor> &inputs, vector<Tensor> &outputs, int32_t op,
+void dist_all_reduce(const vector<Tensor> &inputs, vector<Tensor> &outputs, int32_t op,
                 const std::vector<ncclCommPtr> &user_comms, int nccl_type = -1) {
     const auto len = inputs.size();
 
@@ -206,8 +206,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                 return id;
             }));
     py::class_<ncclCommPtr>(m, "ncclCommPtr").def(py::init<>());
-    m.def("reduce", &reduce, "Reduce");
-    m.def("all_reduce", &all_reduce, "All reduce");
+    m.def("reduce", &dist_reduce, "Reduce");
+    m.def("all_reduce", &dist_all_reduce, "All reduce");
     m.def("get_nccl_uid", &get_nccl_uid, "Get NCCL UID");
     m.def("get_communicator", &get_communicator, "Get communicator");
 }

--- a/msamp/operators/dist_op/dist.cpp
+++ b/msamp/operators/dist_op/dist.cpp
@@ -16,8 +16,6 @@
 #include <utility>
 #include <vector>
 
-using namespace torch;
-using namespace std;
 
 ncclComm_t *to_nccl_comm(ncclComm_t *var) { return reinterpret_cast<ncclComm_t *>(var); }
 
@@ -120,7 +118,7 @@ struct NcclCommList {
             }
         }
     }
-    ArrayRef<ncclComm_t> ref() const { return ArrayRef<ncclComm_t>(comms.get(), ndevices); }
+    at::ArrayRef<ncclComm_t> ref() const { return at::ArrayRef<ncclComm_t>(comms.get(), ndevices); }
 };
 
 using device_list = std::vector<int>;
@@ -131,7 +129,7 @@ struct ncclCommPtr {
     ncclComm_t ptr;
 };
 
-ArrayRef<ncclComm_t> get_communicators(TensorList inputs) {
+at::ArrayRef<ncclComm_t> get_communicators(at::TensorList inputs) {
     static auto get_device = [](const at::Tensor &t) -> int { return t.get_device(); };
     device_list devices = fmap(inputs, get_device);
     auto it = _communicators.find(devices);
@@ -153,7 +151,7 @@ ncclCommPtr get_communicator(ncclUniqueId uid, int rank, int world_size) {
 }
 
 void dist_reduce(const at::Tensor &input, at::Tensor &output, int32_t root, int32_t op, const ncclCommPtr &user_comm,
-            int nccl_type = -1) {
+                 int nccl_type = -1) {
     ncclDataType_t data_type = nccl_type == -1 ? to_nccl_data_type(input) : (ncclDataType_t)nccl_type;
 
     const auto count = input.numel();
@@ -169,8 +167,9 @@ void dist_reduce(const at::Tensor &input, at::Tensor &output, int32_t root, int3
                           to_nccl_comm(comm), stream));
 }
 
-void dist_all_reduce(const vector<Tensor> &inputs, vector<Tensor> &outputs, int32_t op,
-                const std::vector<ncclCommPtr> &user_comms, int nccl_type = -1) {
+void dist_all_reduce(const std::vector<at::Tensor> &inputs, std::vector<at::Tensor> &outputs,
+                     int32_t op,
+                     const std::vector<ncclCommPtr> &user_comms, int nccl_type = -1) {
     const auto len = inputs.size();
 
     ncclDataType_t data_type = nccl_type == -1 ? to_nccl_data_type(inputs[0]) : (ncclDataType_t)nccl_type;

--- a/msamp/operators/dist_op/setup.py
+++ b/msamp/operators/dist_op/setup.py
@@ -24,6 +24,7 @@ setup(
             ['dist.cpp'],
             define_macros=define_macros,
             extra_compile_args=extra_compile_args,
+            libraries=['nccl'],
         )
     ],
     cmdclass={'build_ext': BuildExtension}


### PR DESCRIPTION
**Description**
In PyTorch 2.0, when building `msamp_dist_op`, it raises the following error:
```
    /root/ms-amp/msamp/operators/dist_op/dist.cpp:209:38: error: no matching function for call to ‘pybind11::module_::def(const char [7], <unresolved overloaded function type>, const char [7])’
                                  209 |     m.def("reduce", &reduce, "Reduce");
                                      |                                      ^   
```

The cause is that there is a function called `reduce` in torch namespace. The function name is the same as that of our custom function.

In this PR, I rename the two functions `reduce` and `all_reduce`. Fix #42 

**Major Revision**
- rename two functions, i.e. `reduce` and `all_reduce` in `dist_op/dist.cpp`.
- remove `using namespace torch/std;` in dist_op
- link system nccl by adding `libraries=['nccl']` in setup.py