### PR TITLE
[Bug Fixed] `state` is not found when using FP32 optimizer states for LBAdamWBase

### DIFF
--- a/msamp/optim/adamw_base.py
+++ b/msamp/optim/adamw_base.py
@@ -121,11 +121,11 @@ class LBAdamWBase(LBOptimizer):
             group.setdefault('amsgrad', False)
             group.setdefault('maximize', False)
 
-    def _get_state_tensor(self, tensor, dtype):
+    def _get_state_tensor(self, state, dtype):
         """Get the state tensor of the given dtype.
 
         Args:
-            tensor (torch.Tensor): the orignal tensor.
+            state (torch.Tensor): the orignal state tensor.
             dtype (torch.dtype): the dtype of the state tensor.
 
         Returns:
@@ -135,7 +135,7 @@ class LBAdamWBase(LBOptimizer):
             if dtype not in [torch.uint8, torch.int8, torch.float16]:
                 raise TypeError('Unsupported dtype: {}'.format(dtype))
             qtype = Dtypes.dtype_to_qtype[dtype]
-            state = tensor.cast(qtype)
+            state = state.cast(qtype)
         return state
 
     def _update_lp_tensor(self, lp, hp):

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -148,6 +148,21 @@ class LBAdamwTestCase(unittest.TestCase):
 
         self.assertTrue(torch.equal(model1.weight.value, model2.weight.value))
 
+    def check_LBAdamWBase_state_dtypes(self):
+        """Check the dtype of LBAdamWBase optimizer state."""
+        from msamp.optim import LBAdamW
+        dtypes = [torch.uint8, torch.int8, torch.float16, torch.float32]
+        linear = torch.nn.Linear(4, 8).cuda()
+        model = LinearReplacer.replace(linear, Dtypes.kfloat16)
+        x = torch.randn((4, 4), device='cuda', dtype=torch.float32)
+        for exp_avg_dtype in dtypes:
+            for exp_avg_sq_dtype in dtypes:
+                y = model(x)
+                y.sum().backward()
+                opt = LBAdamW(model.parameters(), exp_avg_dtype=exp_avg_dtype, exp_avg_sq_dtype=exp_avg_sq_dtype)
+                opt.step()
+                opt.zero_grad(set_to_none=True)
+
     @decorator.cuda_test
     def test_historical_window_quantization(self):
         """Test historical window quantization."""

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -151,7 +151,6 @@ class LBAdamwTestCase(unittest.TestCase):
 
     def test_lb_adamw_base_state_dtypes(self):
         """Check the dtype of LBAdamWBase optimizer state."""
-        from msamp.optim.adamw_base import LBAdamWBase
         dtypes = [torch.uint8, torch.int8, torch.float16]
         linear = torch.nn.Linear(4, 8).cuda()
         model = LinearReplacer.replace(linear, Dtypes.kfloat16)
@@ -168,7 +167,6 @@ class LBAdamwTestCase(unittest.TestCase):
     @decorator.cuda_test
     def test_historical_window_quantization(self):
         """Test historical window quantization."""
-        from msamp.optim import LBAdamW
         linear = torch.nn.Linear(4, 8).cuda()
         model = LinearReplacer.replace(linear, Dtypes.kfloat16)
         opt = LBAdamW(model.parameters())


### PR DESCRIPTION
**Description**
In `LBAdamWBase._get_state_tensor` (https://github.com/Azure/MS-AMP/blob/main/msamp/optim/adamw_base.py#L124), the return value is not found when dtype is torch.float32.

```python
    def _get_state_tensor(self, tensor, dtype):
        if dtype != torch.float32:
            if dtype not in [torch.uint8, torch.int8, torch.float16]:
                raise TypeError('Unsupported dtype: {}'.format(dtype))
            qtype = Dtypes.dtype_to_qtype[dtype]
            state = tensor.cast(qtype)
        return state  # state is not found when dtype is torch.float32
```

**Major Revision**
- Fix the bug in `LBAdamWBase._get_state_tensor`
- Add the unit-test for optimizer states
