### PR TITLE
[Bug Fixed] Fix all reduce grads when training more than one models

### DIFF
--- a/msamp/optim/optimizer.py
+++ b/msamp/optim/optimizer.py
@@ -46,8 +46,6 @@ class LBOptimizer(Optimizer):
 
     def all_reduce_grads(self, model):
         """All-reduce gradients of parameters."""
-        if not model_state.ready_to_all_reduce_grads:
-            return
         scaling_params = [p for p in model.parameters() if isinstance(p, ScalingParameter)]
         grads = [p.grad for p in scaling_params if p.grad is not None]
         TensorDist.all_reduce_avg(grads)

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -73,8 +73,8 @@ class LBAdamwTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(model1.weight, model2.weight.float(), 0, diff))
 
     def test_all_reduce_grads(self):
-        from msamp.common.tensor import TensorDist
         """Test the function `all_reduce_grads`."""
+        from msamp.common.tensor import TensorDist
         input = torch.randn(4, 4, device='cuda')
         model1 = torch.nn.Linear(4, 4).cuda()
         model2 = torch.nn.Linear(4, 4).cuda()

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -9,6 +9,7 @@ import unittest
 import torch
 
 from msamp.common.dtype import Dtypes
+from msamp.common.tensor import TensorDist
 from msamp.optim import LBAdamW, LBAdam, LBAdamWBase, DSAdam
 from msamp.nn import LinearReplacer, model_state
 from tests.helper import decorator
@@ -75,7 +76,6 @@ class LBAdamwTestCase(unittest.TestCase):
 
     def test_all_reduce_grads(self):
         """Test the function `all_reduce_grads`."""
-        from msamp.common.tensor import TensorDist
         input = torch.randn(4, 4, device='cuda')
         model1 = torch.nn.Linear(4, 4).cuda()
         model2 = torch.nn.Linear(4, 4).cuda()

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -85,10 +85,12 @@ class LBAdamwTestCase(unittest.TestCase):
         loss.backward()
         old_all_reduce_avg = TensorDist.all_reduce_avg
         num_grads = 0
+
         def debug_all_reduce_avg(grads):
             nonlocal num_grads
             num_grads += len(grads)
             return old_all_reduce_avg(grads)
+
         TensorDist.all_reduce_avg = debug_all_reduce_avg
         opt.all_reduce_grads(model1)
         self.assertEqual(num_grads, 1)


### PR DESCRIPTION
**Description**
Fix the issue #62 

**Major Revision**
- Remove `model_state.ready_to_all_reduce_grads` check in optimizer
- unit-test
