### PR TITLE
feat(deepspeed): Deepspeed Optimizer with MS-AMP support 

### DIFF
--- a/msamp/common/tensor/tensor_dist.py
+++ b/msamp/common/tensor/tensor_dist.py
@@ -126,3 +126,18 @@ class TensorDist:
                 t.div_(world_size)
         else:
             cls.all_reduce(tensors, dist.ReduceOp.AVG, bucket_size)
+
+    @classmethod
+    def all_reduce_sum(cls, tensors, bucket_size=ALL_REDUCE_BUCKET_SIZE):
+        """All-reduce tensors with sum value across processes in one process group.
+
+        Args:
+            tensors (list of torch.Tensor or ScalingTensor): Tensors to be all-reduced.
+            bucket_size (int): Bucket size in bytes.
+        """
+        world_size = DistUtil.get_world_size()
+        if world_size == 1:
+            return
+        if len(tensors) == 0:
+            return
+        cls.all_reduce(tensors, dist.ReduceOp.SUM, bucket_size)

--- a/msamp/deepspeed/__init__.py
+++ b/msamp/deepspeed/__init__.py
@@ -6,7 +6,6 @@ from typing import Optional, Union
 
 import torch
 from torch.optim import Optimizer
-
 from deepspeed import __version__, __git_hash__, __git_branch__, log_dist, logger,  get_accelerator, \
                       DeepSpeedOptimizerCallable, DeepSpeedSchedulerCallable, DeepSpeedConfig, \
                       DeepSpeedHybridEngine, _LRScheduler, zero, PipelineModule, PipelineEngine

--- a/msamp/deepspeed/__init__.py
+++ b/msamp/deepspeed/__init__.py
@@ -2,21 +2,167 @@
 # Licensed under the MIT License.
 
 """DeepSpeed Extension with MS-AMP-support."""
+from typing import Optional, Union
 
-# flake8: noqa
-# ignore the warnings of flake8 since we use the source of deepspeed to initialize
+import torch
+from torch.optim import Optimizer
 
-import inspect
-from deepspeed import *
-from deepspeed import _LRScheduler, _parse_version
-from deepspeed.accelerator import get_accelerator
-from .runtime.engine import MSAMPDeepSpeedEngine as DeepSpeedEngine
+from deepspeed import __version__, __git_hash__, __git_branch__, log_dist, logger,  get_accelerator, \
+                      DeepSpeedOptimizerCallable, DeepSpeedSchedulerCallable, DeepSpeedConfig, \
+                      DeepSpeedHybridEngine, _LRScheduler, zero, PipelineModule, PipelineEngine
 
-# Export version information
-__version__ = version
-__version_major__, __version_minor__, __version_patch__ = _parse_version(__version__)
-__git_hash__ = git_hash
-__git_branch__ = git_branch
+from msamp.deepspeed.runtime.engine import MSAMPDeepSpeedEngine
 
-# Re-create deepspeed.initialize
-exec(compile(inspect.getsource(initialize), '<string>', mode='exec'))
+
+def initialize(
+    args=None,
+    model: torch.nn.Module = None,
+    optimizer: Optional[Union[Optimizer, DeepSpeedOptimizerCallable]] = None,
+    model_parameters: Optional[torch.nn.Module] = None,
+    training_data: Optional[torch.utils.data.Dataset] = None,
+    lr_scheduler: Optional[Union[_LRScheduler, DeepSpeedSchedulerCallable]] = None,
+    mpu=None,
+    dist_init_required: Optional[bool] = None,
+    collate_fn=None,
+    config=None,
+    config_params=None
+):
+    """Initialize the DeepSpeed Engine.
+
+    Arguments:
+        args: an object containing local_rank and deepspeed_config fields.
+            This is optional if `config` is passed.
+
+        model: Required: nn.module class before apply any wrappers
+
+        optimizer: Optional: a user defined Optimizer or Callable that returns an Optimizer object.
+            This overrides any optimizer definition in the DeepSpeed json config.
+
+        model_parameters: Optional: An iterable of torch.Tensors or dicts.
+            Specifies what Tensors should be optimized.
+
+        training_data: Optional: Dataset of type torch.utils.data.Dataset
+
+        lr_scheduler: Optional: Learning Rate Scheduler Object or a Callable that takes an Optimizer
+            and returns a Scheduler object. The scheduler object should define a get_lr(), step(),
+            state_dict(), and load_state_dict() methods
+
+        mpu: Optional: A model parallelism unit object that implements
+            get_{model,data}_parallel_{rank,group,world_size}()
+
+        dist_init_required: Optional: None will auto-initialize torch distributed if needed,
+            otherwise the user can force it to be initialized or not via boolean.
+
+        collate_fn: Optional: Merges a list of samples to form a
+            mini-batch of Tensor(s).  Used when using batched loading from a
+            map-style dataset.
+
+        config: Optional: Instead of requiring args.deepspeed_config you can pass your deepspeed config
+            as an argument instead, as a path or a dictionary.
+
+        config_params: Optional: Same as `config`, kept for backwards compatibility.
+
+    Returns:
+        A tuple of ``engine``, ``optimizer``, ``training_dataloader``, ``lr_scheduler``
+
+        * ``engine``: DeepSpeed runtime engine which wraps the client model for distributed training.
+
+        * ``optimizer``: Wrapped optimizer if a user defined ``optimizer`` is supplied, or if
+          optimizer is specified in json config else ``None``.
+
+        * ``training_dataloader``: DeepSpeed dataloader if ``training_data`` was supplied,
+          otherwise ``None``.
+
+        * ``lr_scheduler``: Wrapped lr scheduler if user ``lr_scheduler`` is passed, or
+          if ``lr_scheduler`` specified in JSON configuration. Otherwise ``None``.
+    """
+
+    log_dist(
+        "DeepSpeed info: version={}, git-hash={}, git-branch={}".format(__version__, __git_hash__, __git_branch__),
+        ranks=[0]
+    )
+
+    # Disable zero.Init context if it's currently enabled
+    zero.partition_parameters.shutdown_init_context()
+
+    assert model is not None, "deepspeed.initialize requires a model"
+
+    global dist
+    from deepspeed import comm as dist
+    dist_backend = get_accelerator().communication_backend_name()
+    dist.init_distributed(dist_backend=dist_backend, dist_init_required=dist_init_required)
+
+    # Set config using config_params for backwards compat
+    if config is None and config_params is not None:
+        config = config_params
+
+    # Check for deepscale_config for backwards compat
+    if hasattr(args, "deepscale_config") and args.deepscale_config is not None:
+        logger.warning("************ --deepscale_config is deprecated, please use --deepspeed_config ************")
+        if hasattr(args, "deepspeed_config"):
+            assert (
+                args.deepspeed_config is None
+            ), "Not sure how to proceed, we were given both a deepscale_config and deepspeed_config"
+        args.deepspeed_config = args.deepscale_config
+        args.deepscale_config = None
+
+    # Check that we have only one config passed
+    if hasattr(args, "deepspeed_config") and args.deepspeed_config is not None:
+        assert config is None, "Not sure how to proceed, we were given deepspeed configs in the deepspeed arguments " \
+             " and deepspeed.initialize() function call"
+        config = args.deepspeed_config
+    assert config is not None, "DeepSpeed requires --deepspeed_config to specify configuration file"
+
+    if not isinstance(model, PipelineModule):
+        config_class = DeepSpeedConfig(config, mpu)
+        if config_class.hybrid_engine.enabled:
+            engine = DeepSpeedHybridEngine(
+                args=args,
+                model=model,
+                optimizer=optimizer,
+                model_parameters=model_parameters,
+                training_data=training_data,
+                lr_scheduler=lr_scheduler,
+                mpu=mpu,
+                dist_init_required=dist_init_required,
+                collate_fn=collate_fn,
+                config=config,
+                config_class=config_class
+            )
+        else:
+            engine = MSAMPDeepSpeedEngine(
+                args=args,
+                model=model,
+                optimizer=optimizer,
+                model_parameters=model_parameters,
+                training_data=training_data,
+                lr_scheduler=lr_scheduler,
+                mpu=mpu,
+                dist_init_required=dist_init_required,
+                collate_fn=collate_fn,
+                config=config,
+                config_class=config_class
+            )
+    else:
+        assert mpu is None, "mpu must be None with pipeline parallelism"
+        mpu = model.mpu()
+        config_class = DeepSpeedConfig(config, mpu)
+        engine = PipelineEngine(
+            args=args,
+            model=model,
+            optimizer=optimizer,
+            model_parameters=model_parameters,
+            training_data=training_data,
+            lr_scheduler=lr_scheduler,
+            mpu=mpu,
+            dist_init_required=dist_init_required,
+            collate_fn=collate_fn,
+            config=config,
+            config_class=config_class
+        )
+
+    return_items = [engine, engine.optimizer, engine.training_dataloader, engine.lr_scheduler]
+    return tuple(return_items)
+
+
+__all__ = ['initialize']

--- a/msamp/deepspeed/__init__.py
+++ b/msamp/deepspeed/__init__.py
@@ -1,0 +1,15 @@
+import inspect
+from deepspeed import *
+from deepspeed import _LRScheduler, _parse_version
+from deepspeed.accelerator import get_accelerator
+from .runtime.engine import MSAMPDeepSpeedEngine as DeepSpeedEngine
+
+# Export version information
+__version__ = version
+__version_major__, __version_minor__, __version_patch__ = _parse_version(__version__)
+__git_hash__ = git_hash
+__git_branch__ = git_branch
+
+
+# Re-create deepspeed.initialize
+exec(compile(inspect.getsource(initialize), '<string>', mode='exec'))

--- a/msamp/deepspeed/__init__.py
+++ b/msamp/deepspeed/__init__.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 """DeepSpeed Extension with MS-AMP support."""
+
 from typing import Optional, Union
 
 import torch

--- a/msamp/deepspeed/__init__.py
+++ b/msamp/deepspeed/__init__.py
@@ -76,16 +76,15 @@ def initialize(
         * ``lr_scheduler``: Wrapped lr scheduler if user ``lr_scheduler`` is passed, or
           if ``lr_scheduler`` specified in JSON configuration. Otherwise ``None``.
     """
-
     log_dist(
-        "DeepSpeed info: version={}, git-hash={}, git-branch={}".format(__version__, __git_hash__, __git_branch__),
+        'DeepSpeed info: version={}, git-hash={}, git-branch={}'.format(__version__, __git_hash__, __git_branch__),
         ranks=[0]
     )
 
     # Disable zero.Init context if it's currently enabled
     zero.partition_parameters.shutdown_init_context()
 
-    assert model is not None, "deepspeed.initialize requires a model"
+    assert model is not None, 'deepspeed.initialize requires a model'
 
     global dist
     from deepspeed import comm as dist
@@ -97,21 +96,21 @@ def initialize(
         config = config_params
 
     # Check for deepscale_config for backwards compat
-    if hasattr(args, "deepscale_config") and args.deepscale_config is not None:
-        logger.warning("************ --deepscale_config is deprecated, please use --deepspeed_config ************")
-        if hasattr(args, "deepspeed_config"):
+    if hasattr(args, 'deepscale_config') and args.deepscale_config is not None:
+        logger.warning('************ --deepscale_config is deprecated, please use --deepspeed_config ************')
+        if hasattr(args, 'deepspeed_config'):
             assert (
                 args.deepspeed_config is None
-            ), "Not sure how to proceed, we were given both a deepscale_config and deepspeed_config"
+            ), 'Not sure how to proceed, we were given both a deepscale_config and deepspeed_config'
         args.deepspeed_config = args.deepscale_config
         args.deepscale_config = None
 
     # Check that we have only one config passed
-    if hasattr(args, "deepspeed_config") and args.deepspeed_config is not None:
-        assert config is None, "Not sure how to proceed, we were given deepspeed configs in the deepspeed arguments " \
-             " and deepspeed.initialize() function call"
+    if hasattr(args, 'deepspeed_config') and args.deepspeed_config is not None:
+        assert config is None, 'Not sure how to proceed, we were given deepspeed configs in the deepspeed arguments ' \
+             ' and deepspeed.initialize() function call'
         config = args.deepspeed_config
-    assert config is not None, "DeepSpeed requires --deepspeed_config to specify configuration file"
+    assert config is not None, 'DeepSpeed requires --deepspeed_config to specify configuration file'
 
     if not isinstance(model, PipelineModule):
         config_class = DeepSpeedConfig(config, mpu)
@@ -144,7 +143,7 @@ def initialize(
                 config_class=config_class
             )
     else:
-        assert mpu is None, "mpu must be None with pipeline parallelism"
+        assert mpu is None, 'mpu must be None with pipeline parallelism'
         mpu = model.mpu()
         config_class = DeepSpeedConfig(config, mpu)
         engine = PipelineEngine(

--- a/msamp/deepspeed/__init__.py
+++ b/msamp/deepspeed/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""DeepSpeed Extension with MS-AMP-support."""
+"""DeepSpeed Extension with MS-AMP support."""
 from typing import Optional, Union
 
 import torch

--- a/msamp/deepspeed/__init__.py
+++ b/msamp/deepspeed/__init__.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 
 import torch
 from torch.optim import Optimizer
-from deepspeed import *  # noqa
+from deepspeed import *    # noqa
 from deepspeed import __version__, __git_hash__, __git_branch__, log_dist, logger,  get_accelerator, \
                       DeepSpeedOptimizerCallable, DeepSpeedSchedulerCallable, DeepSpeedConfig, \
                       DeepSpeedHybridEngine, _LRScheduler, zero, PipelineModule, PipelineEngine

--- a/msamp/deepspeed/__init__.py
+++ b/msamp/deepspeed/__init__.py
@@ -6,6 +6,7 @@ from typing import Optional, Union
 
 import torch
 from torch.optim import Optimizer
+from deepspeed import *  # noqa
 from deepspeed import __version__, __git_hash__, __git_branch__, log_dist, logger,  get_accelerator, \
                       DeepSpeedOptimizerCallable, DeepSpeedSchedulerCallable, DeepSpeedConfig, \
                       DeepSpeedHybridEngine, _LRScheduler, zero, PipelineModule, PipelineEngine

--- a/msamp/deepspeed/__init__.py
+++ b/msamp/deepspeed/__init__.py
@@ -1,3 +1,11 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""DeepSpeed Extension with MS-AMP-support."""
+
+# flake8: noqa
+# ignore the warnings of flake8 since we use the source of deepspeed to initialize
+
 import inspect
 from deepspeed import *
 from deepspeed import _LRScheduler, _parse_version
@@ -9,7 +17,6 @@ __version__ = version
 __version_major__, __version_minor__, __version_patch__ = _parse_version(__version__)
 __git_hash__ = git_hash
 __git_branch__ = git_branch
-
 
 # Re-create deepspeed.initialize
 exec(compile(inspect.getsource(initialize), '<string>', mode='exec'))

--- a/msamp/deepspeed/runtime/config.py
+++ b/msamp/deepspeed/runtime/config.py
@@ -1,0 +1,9 @@
+from deepspeed.runtime.config import *
+
+MSAMP_ADAM_OPTIMIZER = 'mfp8_adam'
+MSAMP_ADAMW_OPTIMIZER = 'mfp8_adamw'
+
+DEEPSPEED_OPTIMIZERS.extend([
+    MSAMP_ADAM_OPTIMIZER,
+    MSAMP_ADAMW_OPTIMIZER,
+])

--- a/msamp/deepspeed/runtime/config.py
+++ b/msamp/deepspeed/runtime/config.py
@@ -1,7 +1,7 @@
 from deepspeed.runtime.config import *
 
-MSAMP_ADAM_OPTIMIZER = 'mfp8_adam'
-MSAMP_ADAMW_OPTIMIZER = 'mfp8_adamw'
+MSAMP_ADAM_OPTIMIZER = 'msamp_adam'
+MSAMP_ADAMW_OPTIMIZER = 'msamp_adamw'
 
 DEEPSPEED_OPTIMIZERS.extend([
     MSAMP_ADAM_OPTIMIZER,

--- a/msamp/deepspeed/runtime/config.py
+++ b/msamp/deepspeed/runtime/config.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""DeepSpeed Config with MS-AMP-support."""
+"""DeepSpeed Config with MS-AMP support."""
 
 # flake8: noqa: F403
 from deepspeed.runtime.config import *

--- a/msamp/deepspeed/runtime/config.py
+++ b/msamp/deepspeed/runtime/config.py
@@ -3,13 +3,11 @@
 
 """DeepSpeed Config with MS-AMP support."""
 
-# flake8: noqa: F403
-from deepspeed.runtime.config import *
+from deepspeed.runtime.config import DEEPSPEED_OPTIMIZERS
 
 MSAMP_ADAM_OPTIMIZER = 'msamp_adam'
 MSAMP_ADAMW_OPTIMIZER = 'msamp_adamw'
 
-# flake8: noqa: F405
 DEEPSPEED_OPTIMIZERS.extend([
     MSAMP_ADAM_OPTIMIZER,
     MSAMP_ADAMW_OPTIMIZER,

--- a/msamp/deepspeed/runtime/config.py
+++ b/msamp/deepspeed/runtime/config.py
@@ -1,8 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""DeepSpeed Config with MS-AMP-support."""
+
+# flake8: noqa: F403
 from deepspeed.runtime.config import *
 
 MSAMP_ADAM_OPTIMIZER = 'msamp_adam'
 MSAMP_ADAMW_OPTIMIZER = 'msamp_adamw'
 
+# flake8: noqa: F405
 DEEPSPEED_OPTIMIZERS.extend([
     MSAMP_ADAM_OPTIMIZER,
     MSAMP_ADAMW_OPTIMIZER,

--- a/msamp/deepspeed/runtime/constants.py
+++ b/msamp/deepspeed/runtime/constants.py
@@ -1,0 +1,6 @@
+from deepspeed.runtime.constants import *
+
+#########################################
+# FP8 support
+#########################################
+FP8 = "fp8"

--- a/msamp/deepspeed/runtime/constants.py
+++ b/msamp/deepspeed/runtime/constants.py
@@ -1,6 +1,0 @@
-from deepspeed.runtime.constants import *
-
-#########################################
-# FP8 support
-#########################################
-FP8 = "fp8"

--- a/msamp/deepspeed/runtime/engine.py
+++ b/msamp/deepspeed/runtime/engine.py
@@ -1,21 +1,28 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# this file is adapted from deepspeed (Copyright (c) Microsoft Corporation. SPDX-License-Identifier: Apache-2.0. DeepSpeed Team)
+
+# flake8: noqa: F405, Q000
+
 import deepspeed
 from deepspeed.runtime.engine import *
 
 from .fp8.fused_optimizer import FP8_Optimizer
 from .config import MSAMP_ADAM_OPTIMIZER, MSAMP_ADAMW_OPTIMIZER
-from .constants import FP8
 
-import msamp
 from msamp.common.tensor import ScalingTensor, ScalingMeta
 from msamp.optim.optimizer import LBOptimizer
+from msamp.optim import LBAdam as MSAMP_Adam, LBAdamW as MSAMP_AdamW, DSAdam
 from msamp.common.dtype import Dtypes
+from msamp.common.tensor import TensorDist
 
 
 def split_half_float_double_sparse(tensors):
+    """
+    Split tensors into buckets of the same type.
+    """
     supported_types = [
-        "torch.cuda.HalfTensor",
-        "torch.cuda.FloatTensor", "torch.cuda.DoubleTensor",
-        "torch.cuda.BFloat16Tensor",
+        "torch.cuda.HalfTensor", "torch.cuda.FloatTensor", "torch.cuda.DoubleTensor", "torch.cuda.BFloat16Tensor",
         "msamp.common.tensor.tensor.ScalingTensor",
         SparseTensor.type()
     ]
@@ -32,7 +39,6 @@ def split_half_float_double_sparse(tensors):
 
 
 deepspeed.runtime.engine.split_half_float_double_sparse = split_half_float_double_sparse
-
 
 _origin_DeepSpeedEngine = deepspeed.runtime.engine.DeepSpeedEngine
 
@@ -56,9 +62,7 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
                 client_optimizer.param_groups[:] = [
                     pg for pg in client_optimizer.param_groups if len(pg["params"]) != 0
                 ]
-                log_dist(
-                    "Removing param_group that has no 'params' in the client Optimizer",
-                    ranks=[0])
+                log_dist("Removing param_group that has no 'params' in the client Optimizer", ranks=[0])
 
                 basic_optimizer = client_optimizer
                 log_dist('Using client Optimizer as basic optimizer', ranks=[0])
@@ -67,16 +71,12 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
                 log_dist('Using client callable to create basic optimizer', ranks=[0])
         else:
             basic_optimizer = self._configure_basic_optimizer(model_parameters)
-            log_dist(
-                f"Using DeepSpeed Optimizer param name {self.optimizer_name()} as basic optimizer",
-                ranks=[0])
+            log_dist(f"Using DeepSpeed Optimizer param name {self.optimizer_name()} as basic optimizer", ranks=[0])
 
         self._check_for_duplicates(basic_optimizer)
 
         self.basic_optimizer = basic_optimizer
-        log_dist("DeepSpeed Basic Optimizer = {}".format(
-            basic_optimizer.__class__.__name__),
-                 ranks=[0])
+        log_dist("DeepSpeed Basic Optimizer = {}".format(basic_optimizer.__class__.__name__), ranks=[0])
 
         optimizer_wrapper = self._do_optimizer_sanity_check(basic_optimizer)
         use_fp8 = False
@@ -90,9 +90,7 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
         elif optimizer_wrapper == AMP:
             amp_params = self.amp_params()
             log_dist(f"Initializing AMP with these params: {amp_params}", ranks=[0])
-            model, self.optimizer = amp.initialize(
-                self.module, basic_optimizer, **amp_params
-            )
+            model, self.optimizer = amp.initialize(self.module, basic_optimizer, **amp_params)
             self._set_client_model(model)
             self._broadcast_model()
             # TODO: maybe need to broadcast experts differently?
@@ -103,8 +101,7 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
         else:
             self.optimizer = basic_optimizer
 
-        log_dist("DeepSpeed Final Optimizer = {}".format(self.optimizer_name()),
-                 ranks=[0])
+        log_dist("DeepSpeed Final Optimizer = {}".format(self.optimizer_name()), ranks=[0])
 
         self.compression_scheduler = self._configure_compression_scheduler()
         self.quantizer = self._configure_quantization()
@@ -124,27 +121,23 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
             adam_w_mode = optimizer_parameters.pop(ADAM_W_MODE, ADAM_W_MODE_DEFAULT)
 
             # Optimizer name of Adam forces AdamW logic unless adam_w_mode is explicitly set
-            effective_adam_w_mode = self.optimizer_name(
-            ) == ADAMW_OPTIMIZER or adam_w_mode
+            effective_adam_w_mode = self.optimizer_name() == ADAMW_OPTIMIZER or adam_w_mode
 
             if torch_adam:
                 if not effective_adam_w_mode:
-                    optimizer = torch.optim.Adam(model_parameters,
-                                                 **optimizer_parameters)
+                    optimizer = torch.optim.Adam(model_parameters, **optimizer_parameters)
                 else:
-                    optimizer = torch.optim.AdamW(model_parameters,
-                                                  **optimizer_parameters)
+                    optimizer = torch.optim.AdamW(model_parameters, **optimizer_parameters)
             else:
                 if self.zero_use_cpu_optimizer():
                     if self.optimizer_name() == ADAGRAD_OPTIMIZER:
                         from deepspeed.ops.adagrad import DeepSpeedCPUAdagrad
-                        optimizer = DeepSpeedCPUAdagrad(model_parameters,
-                                                        **optimizer_parameters)
+                        optimizer = DeepSpeedCPUAdagrad(model_parameters, **optimizer_parameters)
                     else:
                         from deepspeed.ops.adam import DeepSpeedCPUAdam
-                        optimizer = DeepSpeedCPUAdam(model_parameters,
-                                                     **optimizer_parameters,
-                                                     adamw_mode=effective_adam_w_mode)
+                        optimizer = DeepSpeedCPUAdam(
+                            model_parameters, **optimizer_parameters, adamw_mode=effective_adam_w_mode
+                        )
                 else:
                     from deepspeed.ops.adam import FusedAdam
 
@@ -157,17 +150,13 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
         elif self.optimizer_name() in [MSAMP_ADAM_OPTIMIZER, MSAMP_ADAMW_OPTIMIZER]:
             torch_adam = optimizer_parameters.pop(TORCH_ADAM_PARAM, False)
             adam_w_mode = optimizer_parameters.pop(ADAM_W_MODE, ADAM_W_MODE_DEFAULT)
-            effective_adam_w_mode = self.optimizer_name(
-            ) == MSAMP_ADAMW_OPTIMIZER or adam_w_mode
-            from msamp.optim import LBAdam as MSAMP_Adam, LBAdamW as MSAMP_AdamW, DSAdam
+            effective_adam_w_mode = self.optimizer_name() == MSAMP_ADAMW_OPTIMIZER or adam_w_mode
 
             if torch_adam:
                 if not effective_adam_w_mode:
-                    optimizer = MSAMP_Adam(model_parameters,
-                                          **optimizer_parameters)
+                    optimizer = MSAMP_Adam(model_parameters, **optimizer_parameters)
                 else:
-                    optimizer = MSAMP_AdamW(model_parameters,
-                                           **optimizer_parameters)
+                    optimizer = MSAMP_AdamW(model_parameters, **optimizer_parameters)
             else:
                 if self.zero_use_cpu_optimizer():
                     raise NotImplementedError('Not implemented on ZeRO CPU Optimizer')
@@ -188,26 +177,21 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
 
             optimizer = OnebitAdam(model_parameters, self, **optimizer_parameters)
             if not self.fp16_enabled():
-                logger.warning(
-                    f"Currently the convergence of 1-bit Adam is only verified under FP16"
-                )
+                logger.warning(f"Currently the convergence of 1-bit Adam is only verified under FP16")
         elif self.optimizer_name() == ZERO_ONE_ADAM_OPTIMIZER:
             assert not self.zero_optimization(), "0/1 Adam is not compatible with ZeRO"
             from deepspeed.runtime.fp16.onebit.zoadam import ZeroOneAdam
 
             optimizer = ZeroOneAdam(model_parameters, self, **optimizer_parameters)
             if not self.fp16_enabled():
-                logger.warning(
-                    f'Currently the convergence of 0/1 Adam is only verified under FP16')
+                logger.warning(f'Currently the convergence of 0/1 Adam is only verified under FP16')
         elif self.optimizer_name() == ONEBIT_LAMB_OPTIMIZER:
             assert not self.zero_optimization(), "1bit-Lamb is not compatible with ZeRO"
             from deepspeed.runtime.fp16.onebit.lamb import OnebitLamb
 
             optimizer = OnebitLamb(model_parameters, self, **optimizer_parameters)
             if not self.fp16_enabled():
-                logger.warning(
-                    f"Currently the convergence of 1-bit Lamb is only verified under FP16"
-                )
+                logger.warning(f"Currently the convergence of 1-bit Lamb is only verified under FP16")
         else:
             torch_optimizer = getattr(torch.optim, self.optimizer_name())
             optimizer = torch_optimizer(model_parameters, **optimizer_parameters)
@@ -239,8 +223,7 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
             )
         else:
             log_dist(
-                "Creating fp8 optimizer with static loss scale: {}".format(
-                    self.loss_scale()),
+                "Creating fp8 optimizer with static loss scale: {}".format(self.loss_scale()),
                 ranks=[0],
             )
             loss_scale = self.loss_scale()
@@ -276,8 +259,7 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
             round_robin_gradients = self.zero_round_robin_gradients()
             assert not isinstance(optimizer, DummyOptim), "zero stage {} requires an optimizer".format(zero_stage)
 
-            log_dist('Creating fp16 ZeRO stage {} optimizer'.format(zero_stage),
-                     ranks=[0])
+            log_dist('Creating fp16 ZeRO stage {} optimizer'.format(zero_stage), ranks=[0])
             # Overlap and contiguous grads are meaningless in stage 1 and are ignored
             if zero_stage == ZeroStageEnum.optimizer_states:
                 overlap_comm = False
@@ -285,9 +267,7 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
 
             if isinstance(self.module, PipelineModule):
                 if overlap_comm:
-                    logger.warning(
-                        "Pipeline parallelism does not support overlapped communication, will be disabled."
-                    )
+                    logger.warning("Pipeline parallelism does not support overlapped communication, will be disabled.")
                     overlap_comm = False
             if use_fp8:
                 raise NotImplementedError('fp8 ZeRO is not supported yet')
@@ -305,10 +285,8 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
                 reduce_bucket_size=self.zero_reduce_bucket_size(),
                 allgather_bucket_size=self.zero_allgather_bucket_size(),
                 dp_process_group=self.data_parallel_group,
-                expert_parallel_group=self.expert_parallel_group
-                if self.has_moe_layers else None,
-                expert_data_parallel_group=self.expert_data_parallel_group
-                if self.has_moe_layers else None,
+                expert_parallel_group=self.expert_parallel_group if self.has_moe_layers else None,
+                expert_data_parallel_group=self.expert_data_parallel_group if self.has_moe_layers else None,
                 reduce_scatter=self.zero_reduce_scatter(),
                 overlap_comm=overlap_comm,
                 cpu_offload=self.zero_cpu_offload(),
@@ -320,10 +298,10 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
                 partition_grads=zero_stage == ZeroStageEnum.gradients,
                 round_robin_gradients=round_robin_gradients,
                 has_moe_layers=self.has_moe_layers,
-                fp16_master_weights_and_gradients=self.fp16_master_weights_and_gradients(
-                ),
+                fp16_master_weights_and_gradients=self.fp16_master_weights_and_gradients(),
                 communication_data_type=self.communication_data_type,
-                elastic_checkpoint=self.zero_elastic_checkpoint())
+                elastic_checkpoint=self.zero_elastic_checkpoint()
+            )
 
         elif zero_stage == ZeroStageEnum.weights:
             assert not self.has_moe_layers, "MoE not supported with Stage 3"
@@ -340,10 +318,10 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
                     param_persistence_threshold=self.zero_param_persistence_threshold(),
                     model_persistence_threshold=self.zero_model_persistence_threshold(),
                     offload_param_config=self.zero_offload_param(),
-                    mpu=self.mpu)
+                    mpu=self.mpu
+                )
             else:
-                log_dist('Creating fp16 ZeRO stage {} optimizer'.format(zero_stage),
-                         ranks=[0])
+                log_dist('Creating fp16 ZeRO stage {} optimizer'.format(zero_stage), ranks=[0])
                 from deepspeed.runtime.zero.stage3 import DeepSpeedZeroOptimizer_Stage3
                 optimizer = DeepSpeedZeroOptimizer_Stage3(
                     self.module,
@@ -372,7 +350,8 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
                     gradient_predivide_factor=self.gradient_predivide_factor(),
                     gradient_accumulation_steps=self.gradient_accumulation_steps(),
                     aio_config=self.aio_config(),
-                    communication_data_type=self.communication_data_type)
+                    communication_data_type=self.communication_data_type
+                )
 
         else:
             raise NotImplementedError("ZeRO stage {} not implemented".format(zero_stage))
@@ -380,12 +359,7 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
         return optimizer
 
     @instrument_w_nvtx
-    def backward(self,
-                 loss,
-                 allreduce_gradients=True,
-                 release_loss=False,
-                 retain_graph=False,
-                 scale_wrt_gas=True):
+    def backward(self, loss, allreduce_gradients=True, release_loss=False, retain_graph=False, scale_wrt_gas=True):
         r"""Execute backward pass on the loss
         Arguments:
             loss: Torch tensor on which to execute backward propagation
@@ -400,9 +374,7 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
             scale_wrt_gas = self.scale_wrt_gas
 
         if not allreduce_gradients:
-            logger.warning(
-                f"Argument `allreduce_gradients` is deprecated, ignored, and will soon be removed"
-            )
+            logger.warning(f"Argument `allreduce_gradients` is deprecated, ignored, and will soon be removed")
 
         # scale loss w.r.t. gradient accumulation if needed
         if self.gradient_accumulation_steps() > 1 and scale_wrt_gas:
@@ -412,11 +384,13 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
         if self.monitor.enabled:
             if self.is_gradient_accumulation_boundary():
                 if self.global_rank == 0:
-                    self.summary_events = [(
-                        f"Train/Samples/train_loss",
-                        loss.mean().item() * self.gradient_accumulation_steps(),
-                        self.global_samples,
-                    )]
+                    self.summary_events = [
+                        (
+                            f"Train/Samples/train_loss",
+                            loss.mean().item() * self.gradient_accumulation_steps(),
+                            self.global_samples,
+                        )
+                    ]
                     self.monitor.write_events(self.summary_events)
 
         self._start_timers(self.engine_timers.backward_timers)
@@ -427,8 +401,7 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
         self._start_timers(self.engine_timers.backward_inner_timers)
 
         if self.zero_optimization():
-            self.optimizer.is_gradient_accumulation_boundary = self.is_gradient_accumulation_boundary(
-            )
+            self.optimizer.is_gradient_accumulation_boundary = self.is_gradient_accumulation_boundary()
             self.optimizer.backward(loss, retain_graph=retain_graph)
         elif isinstance(self.optimizer, FP8_Optimizer):
             self.optimizer.backward(loss, retain_graph=retain_graph)
@@ -436,9 +409,7 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
             # AMP requires delaying unscale when inside gradient accumulation boundaries
             # https://nvidia.github.io/apex/advanced.html#gradient-accumulation-across-iterations
             delay_unscale = not self.is_gradient_accumulation_boundary()
-            with amp.scale_loss(loss,
-                                self.optimizer,
-                                delay_unscale=delay_unscale) as scaled_loss:
+            with amp.scale_loss(loss, self.optimizer, delay_unscale=delay_unscale) as scaled_loss:
                 scaled_loss.backward(retain_graph=retain_graph)
         elif self.fp16_enabled():
             if self.eigenvalue_enabled():
@@ -475,7 +446,6 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
 
     def fp8_allreduce_bucket(self, bucket, dp_group):
         # TODO: assert dp_group == global_dp_group
-        from msamp.common.tensor import TensorDist
         # in msamp, a.data = b.data. It is not a copy!
         if self.gradient_average:
             TensorDist.all_reduce_avg(bucket)
@@ -513,13 +483,12 @@ class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
                 # sense in the future to support the ability to average not
                 # w.r.t. world size but with a different value.
                 if isinstance(param, ScalingTensor):
-                    param.grad = ScalingTensor(torch.zeros(param.size(),
-                                               dtype=torch.uint8,
-                                               device=param.device), ScalingMeta(Dtypes.kfloat_8e4m3))
+                    param.grad = ScalingTensor(
+                        torch.zeros(param.size(), dtype=torch.uint8, device=param.device),
+                        ScalingMeta(Dtypes.kfloat_8e4m3)
+                    )
                 else:
-                    param.grad = torch.zeros(param.size(),
-                                             dtype=param.dtype,
-                                             device=param.device)
+                    param.grad = torch.zeros(param.size(), dtype=param.dtype, device=param.device)
 
             grad_data = param.grad.data
             if param_name in self.sparse_tensor_module_names or grad_data.is_sparse:

--- a/msamp/deepspeed/runtime/engine.py
+++ b/msamp/deepspeed/runtime/engine.py
@@ -1,0 +1,534 @@
+import deepspeed
+from deepspeed.runtime.engine import *
+
+from .fp8.fused_optimizer import FP8_Optimizer
+from .config import MSAMP_ADAM_OPTIMIZER, MSAMP_ADAMW_OPTIMIZER
+from .constants import FP8
+
+import msamp
+from msamp.common.tensor import ScalingTensor, ScalingMeta
+from msamp.optim.optimizer import LBOptimizer
+from msamp.common.dtype import Dtypes
+
+
+def split_half_float_double_sparse(tensors):
+    supported_types = [
+        "torch.cuda.HalfTensor",
+        "torch.cuda.FloatTensor", "torch.cuda.DoubleTensor",
+        "torch.cuda.BFloat16Tensor",
+        "msamp.common.tensor.tensor.ScalingTensor",
+        SparseTensor.type()
+    ]
+
+    for t in tensors:
+        assert t.type() in supported_types, f"attempting to reduce an unsupported grad type: {t.type()}"
+
+    buckets = []
+    for i, dtype in enumerate(supported_types):
+        bucket = [t for t in tensors if t.type() == dtype]
+        if bucket:
+            buckets.append((dtype, bucket))
+    return buckets
+
+
+deepspeed.runtime.engine.split_half_float_double_sparse = split_half_float_double_sparse
+
+
+_origin_DeepSpeedEngine = deepspeed.runtime.engine.DeepSpeedEngine
+
+
+class MSAMPDeepSpeedEngine(_origin_DeepSpeedEngine):
+    @property
+    def communication_data_type(self):
+        res = self._config.communication_data_type
+        if res is not None:
+            return res
+
+        if self.fp16_enabled():
+            return torch.float16
+
+        return torch.float32
+
+    # Configure optimizer
+    def _configure_optimizer(self, client_optimizer, model_parameters):
+        if client_optimizer is not None:
+            if isinstance(client_optimizer, tuple(self._supported_optims())):
+                client_optimizer.param_groups[:] = [
+                    pg for pg in client_optimizer.param_groups if len(pg["params"]) != 0
+                ]
+                log_dist(
+                    "Removing param_group that has no 'params' in the client Optimizer",
+                    ranks=[0])
+
+                basic_optimizer = client_optimizer
+                log_dist('Using client Optimizer as basic optimizer', ranks=[0])
+            else:
+                basic_optimizer = client_optimizer(model_parameters)
+                log_dist('Using client callable to create basic optimizer', ranks=[0])
+        else:
+            basic_optimizer = self._configure_basic_optimizer(model_parameters)
+            log_dist(
+                f"Using DeepSpeed Optimizer param name {self.optimizer_name()} as basic optimizer",
+                ranks=[0])
+
+        self._check_for_duplicates(basic_optimizer)
+
+        self.basic_optimizer = basic_optimizer
+        log_dist("DeepSpeed Basic Optimizer = {}".format(
+            basic_optimizer.__class__.__name__),
+                 ranks=[0])
+
+        optimizer_wrapper = self._do_optimizer_sanity_check(basic_optimizer)
+        use_fp8 = False
+        if isinstance(basic_optimizer, LBOptimizer):
+            use_fp8 = True
+
+        if optimizer_wrapper == ZERO_OPTIMIZATION or (use_fp8 and optimizer_wrapper == BFLOAT16):
+            self.optimizer = self._configure_zero_optimizer(basic_optimizer, use_fp8=use_fp8)
+        elif use_fp8:
+            self.optimizer = self._configure_fp8_optimizer(basic_optimizer, optimizer_wrapper)
+        elif optimizer_wrapper == AMP:
+            amp_params = self.amp_params()
+            log_dist(f"Initializing AMP with these params: {amp_params}", ranks=[0])
+            model, self.optimizer = amp.initialize(
+                self.module, basic_optimizer, **amp_params
+            )
+            self._set_client_model(model)
+            self._broadcast_model()
+            # TODO: maybe need to broadcast experts differently?
+        elif optimizer_wrapper == FP16:
+            self.optimizer = self._configure_fp16_optimizer(basic_optimizer)
+        elif optimizer_wrapper == BFLOAT16:
+            self.optimizer = self._configure_bf16_optimizer(basic_optimizer)
+        else:
+            self.optimizer = basic_optimizer
+
+        log_dist("DeepSpeed Final Optimizer = {}".format(self.optimizer_name()),
+                 ranks=[0])
+
+        self.compression_scheduler = self._configure_compression_scheduler()
+        self.quantizer = self._configure_quantization()
+
+    def _configure_basic_optimizer(self, model_parameters):
+        optimizer_parameters = self.optimizer_params()
+        if optimizer_parameters is None:
+            optimizer_parameters = {}
+        # print(optimizer_parameters.keys())
+        if "max_grad_norm" in optimizer_parameters.keys():
+            raise ValueError(
+                "'max_grad_norm' is not supported as an optimizer parameter, please switch to using the deepspeed parameter 'gradient_clipping' see: https://www.deepspeed.ai/docs/config-json/#gradient-clipping for more details"
+            )
+
+        if self.optimizer_name() in [ADAGRAD_OPTIMIZER, ADAM_OPTIMIZER, ADAMW_OPTIMIZER]:
+            torch_adam = optimizer_parameters.pop(TORCH_ADAM_PARAM, False)
+            adam_w_mode = optimizer_parameters.pop(ADAM_W_MODE, ADAM_W_MODE_DEFAULT)
+
+            # Optimizer name of Adam forces AdamW logic unless adam_w_mode is explicitly set
+            effective_adam_w_mode = self.optimizer_name(
+            ) == ADAMW_OPTIMIZER or adam_w_mode
+
+            if torch_adam:
+                if not effective_adam_w_mode:
+                    optimizer = torch.optim.Adam(model_parameters,
+                                                 **optimizer_parameters)
+                else:
+                    optimizer = torch.optim.AdamW(model_parameters,
+                                                  **optimizer_parameters)
+            else:
+                if self.zero_use_cpu_optimizer():
+                    if self.optimizer_name() == ADAGRAD_OPTIMIZER:
+                        from deepspeed.ops.adagrad import DeepSpeedCPUAdagrad
+                        optimizer = DeepSpeedCPUAdagrad(model_parameters,
+                                                        **optimizer_parameters)
+                    else:
+                        from deepspeed.ops.adam import DeepSpeedCPUAdam
+                        optimizer = DeepSpeedCPUAdam(model_parameters,
+                                                     **optimizer_parameters,
+                                                     adamw_mode=effective_adam_w_mode)
+                else:
+                    from deepspeed.ops.adam import FusedAdam
+
+                    optimizer = FusedAdam(
+                        model_parameters,
+                        **optimizer_parameters,
+                        adam_w_mode=effective_adam_w_mode,
+                    )
+
+        elif self.optimizer_name() in [MSAMP_ADAM_OPTIMIZER, MSAMP_ADAMW_OPTIMIZER]:
+            torch_adam = optimizer_parameters.pop(TORCH_ADAM_PARAM, False)
+            adam_w_mode = optimizer_parameters.pop(ADAM_W_MODE, ADAM_W_MODE_DEFAULT)
+            effective_adam_w_mode = self.optimizer_name(
+            ) == MSAMP_ADAMW_OPTIMIZER or adam_w_mode
+            from msamp.optim import LBAdam as MSAMP_Adam, LBAdamW as MSAMP_AdamW, DSAdam
+
+            if torch_adam:
+                if not effective_adam_w_mode:
+                    optimizer = MSAMP_Adam(model_parameters,
+                                          **optimizer_parameters)
+                else:
+                    optimizer = MSAMP_AdamW(model_parameters,
+                                           **optimizer_parameters)
+            else:
+                if self.zero_use_cpu_optimizer():
+                    raise NotImplementedError('Not implemented on ZeRO CPU Optimizer')
+                else:
+                    optimizer = DSAdam(
+                        model_parameters,
+                        **optimizer_parameters,
+                        adam_w_mode=effective_adam_w_mode,
+                    )
+
+        elif self.optimizer_name() == LAMB_OPTIMIZER:
+            from deepspeed.ops.lamb import FusedLamb
+
+            optimizer = FusedLamb(model_parameters, **optimizer_parameters)
+        elif self.optimizer_name() == ONEBIT_ADAM_OPTIMIZER:
+            assert not self.zero_optimization(), "1bit-Adam is not compatible with ZeRO"
+            from deepspeed.runtime.fp16.onebit.adam import OnebitAdam
+
+            optimizer = OnebitAdam(model_parameters, self, **optimizer_parameters)
+            if not self.fp16_enabled():
+                logger.warning(
+                    f"Currently the convergence of 1-bit Adam is only verified under FP16"
+                )
+        elif self.optimizer_name() == ZERO_ONE_ADAM_OPTIMIZER:
+            assert not self.zero_optimization(), "0/1 Adam is not compatible with ZeRO"
+            from deepspeed.runtime.fp16.onebit.zoadam import ZeroOneAdam
+
+            optimizer = ZeroOneAdam(model_parameters, self, **optimizer_parameters)
+            if not self.fp16_enabled():
+                logger.warning(
+                    f'Currently the convergence of 0/1 Adam is only verified under FP16')
+        elif self.optimizer_name() == ONEBIT_LAMB_OPTIMIZER:
+            assert not self.zero_optimization(), "1bit-Lamb is not compatible with ZeRO"
+            from deepspeed.runtime.fp16.onebit.lamb import OnebitLamb
+
+            optimizer = OnebitLamb(model_parameters, self, **optimizer_parameters)
+            if not self.fp16_enabled():
+                logger.warning(
+                    f"Currently the convergence of 1-bit Lamb is only verified under FP16"
+                )
+        else:
+            torch_optimizer = getattr(torch.optim, self.optimizer_name())
+            optimizer = torch_optimizer(model_parameters, **optimizer_parameters)
+        return optimizer
+
+    def _configure_fp8_optimizer(self, optimizer, optimizer_wrapper):
+        initial_dynamic_scale = self.initial_dynamic_scale()
+        dynamic_loss_args = self.dynamic_loss_scale_args()
+        clip_grad = self.gradient_clipping()
+        if APEX_INSTALLED:
+            fused_opts = (apex.optimizers.FusedAdam, FusedAdam)
+        else:
+            fused_opts = FusedAdam
+
+        if optimizer_wrapper == FP16 and self.dynamic_loss_scale():
+            log_dist("Creating fp8 optimizer with dynamic loss scale", ranks=[0])
+            timers = self.timers if self.wall_clock_breakdown() else None
+            optimizer = FP8_Optimizer(
+                optimizer,
+                deepspeed=self,
+                dynamic_loss_scale=True,
+                initial_dynamic_scale=initial_dynamic_scale,
+                dynamic_loss_args=dynamic_loss_args,
+                mpu=self.mpu,
+                clip_grad=clip_grad,
+                fused_adam_legacy=self.optimizer_legacy_fusion(),
+                timers=timers,
+                has_moe_layers=self.has_moe_layers,
+            )
+        else:
+            log_dist(
+                "Creating fp8 optimizer with static loss scale: {}".format(
+                    self.loss_scale()),
+                ranks=[0],
+            )
+            loss_scale = self.loss_scale()
+            if loss_scale == 0:
+                loss_scale = 1
+            optimizer = FP8_Optimizer(
+                optimizer,
+                deepspeed=self,
+                static_loss_scale=loss_scale,
+                mpu=self.mpu,
+                clip_grad=clip_grad,
+                fused_adam_legacy=self.optimizer_legacy_fusion(),
+                has_moe_layers=self.has_moe_layers,
+            )
+
+        return optimizer
+
+    def _configure_zero_optimizer(self, optimizer, use_fp8=False):
+        zero_stage = self.zero_optimization_stage()
+        timers = self.timers if self.wall_clock_breakdown() else None
+
+        if optimizer is None:
+            optimizer = DummyOptim(list(self.module.parameters()))
+
+        if self.zero_legacy_stage1():
+            raise Exception(
+                "The deprecated version of ZeRO Stage 1 is not supported in deepspeed >= 0.5.9. Please downgrade to a version less than 0.5.9 if you need to use this deprecated version of ZeRO."
+            )
+
+        if zero_stage <= ZeroStageEnum.gradients:
+            overlap_comm = self.zero_overlap_comm()
+            contiguous_gradients = self.zero_contiguous_gradients()
+            round_robin_gradients = self.zero_round_robin_gradients()
+            assert not isinstance(optimizer, DummyOptim), "zero stage {} requires an optimizer".format(zero_stage)
+
+            log_dist('Creating fp16 ZeRO stage {} optimizer'.format(zero_stage),
+                     ranks=[0])
+            # Overlap and contiguous grads are meaningless in stage 1 and are ignored
+            if zero_stage == ZeroStageEnum.optimizer_states:
+                overlap_comm = False
+                round_robin_gradients = False
+
+            if isinstance(self.module, PipelineModule):
+                if overlap_comm:
+                    logger.warning(
+                        "Pipeline parallelism does not support overlapped communication, will be disabled."
+                    )
+                    overlap_comm = False
+            if use_fp8:
+                raise NotImplementedError('fp8 ZeRO is not supported yet')
+            else:
+                zero_t = DeepSpeedZeroOptimizer
+            optimizer = zero_t(
+                optimizer,
+                self.param_names,
+                timers=timers,
+                static_loss_scale=self.loss_scale(),
+                dynamic_loss_scale=self.dynamic_loss_scale(),
+                dynamic_loss_args=self.dynamic_loss_scale_args(),
+                clip_grad=self.gradient_clipping(),
+                contiguous_gradients=contiguous_gradients,
+                reduce_bucket_size=self.zero_reduce_bucket_size(),
+                allgather_bucket_size=self.zero_allgather_bucket_size(),
+                dp_process_group=self.data_parallel_group,
+                expert_parallel_group=self.expert_parallel_group
+                if self.has_moe_layers else None,
+                expert_data_parallel_group=self.expert_data_parallel_group
+                if self.has_moe_layers else None,
+                reduce_scatter=self.zero_reduce_scatter(),
+                overlap_comm=overlap_comm,
+                cpu_offload=self.zero_cpu_offload(),
+                mpu=self.mpu,
+                postscale_gradients=self.postscale_gradients(),
+                gradient_predivide_factor=self.gradient_predivide_factor(),
+                gradient_accumulation_steps=self.gradient_accumulation_steps(),
+                ignore_unused_parameters=self.zero_ignore_unused_parameters(),
+                partition_grads=zero_stage == ZeroStageEnum.gradients,
+                round_robin_gradients=round_robin_gradients,
+                has_moe_layers=self.has_moe_layers,
+                fp16_master_weights_and_gradients=self.fp16_master_weights_and_gradients(
+                ),
+                communication_data_type=self.communication_data_type,
+                elastic_checkpoint=self.zero_elastic_checkpoint())
+
+        elif zero_stage == ZeroStageEnum.weights:
+            assert not self.has_moe_layers, "MoE not supported with Stage 3"
+            if isinstance(optimizer, DummyOptim):
+                log_dist("Creating ZeRO Offload", ranks=[0])
+                optimizer = DeepSpeedZeRoOffload(
+                    self.module,
+                    timers=timers,
+                    ds_config=self.config,
+                    overlap_comm=self.zero_overlap_comm(),
+                    prefetch_bucket_size=self.zero_prefetch_bucket_size(),
+                    max_reuse_distance=self.zero_max_reuse_distance(),
+                    max_live_parameters=self.zero_max_live_parameters(),
+                    param_persistence_threshold=self.zero_param_persistence_threshold(),
+                    model_persistence_threshold=self.zero_model_persistence_threshold(),
+                    offload_param_config=self.zero_offload_param(),
+                    mpu=self.mpu)
+            else:
+                log_dist('Creating fp16 ZeRO stage {} optimizer'.format(zero_stage),
+                         ranks=[0])
+                from deepspeed.runtime.zero.stage3 import DeepSpeedZeroOptimizer_Stage3
+                optimizer = DeepSpeedZeroOptimizer_Stage3(
+                    self.module,
+                    optimizer,
+                    timers=timers,
+                    ds_config=self.config,
+                    static_loss_scale=self.loss_scale(),
+                    dynamic_loss_scale=self.dynamic_loss_scale(),
+                    dynamic_loss_args=self.dynamic_loss_scale_args(),
+                    clip_grad=self.gradient_clipping(),
+                    contiguous_gradients=self.zero_contiguous_gradients(),
+                    reduce_bucket_size=self.zero_reduce_bucket_size(),
+                    prefetch_bucket_size=self.zero_prefetch_bucket_size(),
+                    max_reuse_distance=self.zero_max_reuse_distance(),
+                    max_live_parameters=self.zero_max_live_parameters(),
+                    param_persistence_threshold=self.zero_param_persistence_threshold(),
+                    model_persistence_threshold=self.zero_model_persistence_threshold(),
+                    dp_process_group=self.data_parallel_group,
+                    reduce_scatter=self.zero_reduce_scatter(),
+                    overlap_comm=self.zero_overlap_comm(),
+                    offload_optimizer_config=self.zero_offload_optimizer(),
+                    offload_param_config=self.zero_offload_param(),
+                    sub_group_size=self.zero_sub_group_size(),
+                    mpu=self.mpu,
+                    postscale_gradients=self.postscale_gradients(),
+                    gradient_predivide_factor=self.gradient_predivide_factor(),
+                    gradient_accumulation_steps=self.gradient_accumulation_steps(),
+                    aio_config=self.aio_config(),
+                    communication_data_type=self.communication_data_type)
+
+        else:
+            raise NotImplementedError("ZeRO stage {} not implemented".format(zero_stage))
+
+        return optimizer
+
+    @instrument_w_nvtx
+    def backward(self,
+                 loss,
+                 allreduce_gradients=True,
+                 release_loss=False,
+                 retain_graph=False,
+                 scale_wrt_gas=True):
+        r"""Execute backward pass on the loss
+        Arguments:
+            loss: Torch tensor on which to execute backward propagation
+            allreduce_gradients: is deprecated, ignored, and will soon be removed'
+            retain_graph: bool, default: false
+                forward on user defined choice of retain_graph
+        """
+
+        see_memory_usage("Engine before backward", force=self.memory_breakdown())
+
+        if self.scale_wrt_gas is not None:
+            scale_wrt_gas = self.scale_wrt_gas
+
+        if not allreduce_gradients:
+            logger.warning(
+                f"Argument `allreduce_gradients` is deprecated, ignored, and will soon be removed"
+            )
+
+        # scale loss w.r.t. gradient accumulation if needed
+        if self.gradient_accumulation_steps() > 1 and scale_wrt_gas:
+            loss = self._scale_loss_by_gas(loss.float())
+
+        # Log training Loss
+        if self.monitor.enabled:
+            if self.is_gradient_accumulation_boundary():
+                if self.global_rank == 0:
+                    self.summary_events = [(
+                        f"Train/Samples/train_loss",
+                        loss.mean().item() * self.gradient_accumulation_steps(),
+                        self.global_samples,
+                    )]
+                    self.monitor.write_events(self.summary_events)
+
+        self._start_timers(self.engine_timers.backward_timers)
+
+        assert self.optimizer is not None and not isinstance(self.optimizer, DummyOptim), \
+            "must provide optimizer during init in order to use backward"
+
+        self._start_timers(self.engine_timers.backward_inner_timers)
+
+        if self.zero_optimization():
+            self.optimizer.is_gradient_accumulation_boundary = self.is_gradient_accumulation_boundary(
+            )
+            self.optimizer.backward(loss, retain_graph=retain_graph)
+        elif isinstance(self.optimizer, FP8_Optimizer):
+            self.optimizer.backward(loss, retain_graph=retain_graph)
+        elif self.amp_enabled():
+            # AMP requires delaying unscale when inside gradient accumulation boundaries
+            # https://nvidia.github.io/apex/advanced.html#gradient-accumulation-across-iterations
+            delay_unscale = not self.is_gradient_accumulation_boundary()
+            with amp.scale_loss(loss,
+                                self.optimizer,
+                                delay_unscale=delay_unscale) as scaled_loss:
+                scaled_loss.backward(retain_graph=retain_graph)
+        elif self.fp16_enabled():
+            if self.eigenvalue_enabled():
+                self.optimizer.backward(loss, create_graph=True, retain_graph=True)
+            else:
+                self.optimizer.backward(loss, retain_graph=retain_graph)
+        elif self.bfloat16_enabled():
+            self.optimizer.backward(loss)
+        else:
+            if self.eigenvalue_enabled():
+                loss.backward(create_graph=True, retain_graph=True)
+            else:
+                loss.backward(retain_graph=retain_graph)
+
+        self._stop_timers(self.engine_timers.backward_inner_timers)
+
+        self._start_timers(self.engine_timers.backward_reduce_timers)
+
+        if allreduce_gradients and self.enable_backward_allreduce:
+            # Traditional code path that allreduces the module parameter grads
+            self.allreduce_gradients()
+
+        self._stop_timers(self.engine_timers.backward_reduce_timers)
+
+        self._stop_timers(self.engine_timers.backward_timers)
+
+        if release_loss:
+            # loss.data = None
+            pass
+
+        see_memory_usage("Engine after backward", force=self.memory_breakdown())
+
+        return loss
+
+    def fp8_allreduce_bucket(self, bucket, dp_group):
+        # TODO: assert dp_group == global_dp_group
+        from msamp.common.tensor import TensorDist
+        # in msamp, a.data = b.data. It is not a copy!
+        if self.gradient_average:
+            TensorDist.all_reduce_avg(bucket)
+        else:
+            TensorDist.all_reduce_sum(bucket)
+
+    def allreduce_gradients(self, bucket_size=MEMORY_OPT_ALLREDUCE_SIZE):
+        from msamp.nn import model_state
+        model_state.ready_to_all_reduce_grads = False
+        return super().allreduce_gradients(bucket_size)
+
+    def allreduce_and_copy(self, small_bucket, dp_group):
+        if len(small_bucket) == 0:
+            return
+        if isinstance(small_bucket[0], ScalingTensor):
+            # ScalingTensor all reduce
+            self.fp8_allreduce_bucket(small_bucket, dp_group)
+            return
+        allreduced = self.allreduce_bucket(small_bucket, dp_group)
+        for buf, synced in zip(small_bucket, self.unflatten(allreduced, small_bucket)):
+            buf.copy_(synced)
+
+    def _get_gradients_for_reduction(self):
+        non_expert_grads = []
+        expert_grads = {}
+        if self.has_moe_layers:
+            for key in self.expert_data_parallel_group.keys():
+                expert_grads[key] = []
+
+        for param_name, param in self.module.named_parameters():
+            if param.grad is None:
+                # In cases where there is an imbalance of empty grads across
+                # ranks we must create empty grads, this will ensure that every
+                # rank is reducing the same size. In some cases it may make
+                # sense in the future to support the ability to average not
+                # w.r.t. world size but with a different value.
+                if isinstance(param, ScalingTensor):
+                    param.grad = ScalingTensor(torch.zeros(param.size(),
+                                               dtype=torch.uint8,
+                                               device=param.device), ScalingMeta(Dtypes.kfloat_8e4m3))
+                else:
+                    param.grad = torch.zeros(param.size(),
+                                             dtype=param.dtype,
+                                             device=param.device)
+
+            grad_data = param.grad.data
+            if param_name in self.sparse_tensor_module_names or grad_data.is_sparse:
+                # Call param.grad without data to avoid problem with setting of updated grads
+                grad_data = SparseTensor(param.grad)
+
+            if is_moe_param(param):
+                expert_grads[param.group_name].append(grad_data)
+            else:
+                non_expert_grads.append(grad_data)
+
+        return non_expert_grads, expert_grads

--- a/msamp/deepspeed/runtime/engine.py
+++ b/msamp/deepspeed/runtime/engine.py
@@ -20,6 +20,7 @@ from msamp.optim.optimizer import LBOptimizer
 from msamp.deepspeed.runtime.fp8.fused_optimizer import FP8Optimizer
 from msamp.deepspeed.runtime.config import MSAMP_ADAM_OPTIMIZER, MSAMP_ADAMW_OPTIMIZER
 
+
 def split_half_float_double_sparse(tensors):
     """Split tensors into buckets of the same type.
 
@@ -355,7 +356,7 @@ class MSAMPDeepSpeedEngine(DeepSpeedEngine):
         if allreduce_gradients and self.enable_backward_allreduce:
             # Traditional code path that allreduces the module parameter grads
             # It will not call optimizer.all_reduce_grads so we set ready_to_all_reduce_grads to False.
-            # In optimizer.step, ready_to_all_reduce_grads is supposed to be False. 
+            # In optimizer.step, ready_to_all_reduce_grads is supposed to be False.
             model_state.ready_to_all_reduce_grads = False
             self.allreduce_gradients()
 

--- a/msamp/deepspeed/runtime/fp8/fused_optimizer.py
+++ b/msamp/deepspeed/runtime/fp8/fused_optimizer.py
@@ -1,0 +1,559 @@
+'''
+Copyright 2019 The Microsoft DeepSpeed Team
+
+Copyright NVIDIA/apex
+This file is adapted from FP8_Optimizer in NVIDIA/apex
+'''
+
+import os
+from itertools import chain
+import torch
+from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
+
+from deepspeed.runtime import DeepSpeedOptimizer
+from deepspeed.runtime.utils import get_global_norm, get_grad_norm, get_weight_norm
+from ..utils import CheckOverflow
+from deepspeed.runtime.fp16.loss_scaler import INITIAL_LOSS_SCALE, SCALE_WINDOW, MIN_LOSS_SCALE
+from deepspeed.utils import groups, logger, log_dist
+from deepspeed import comm as dist
+from deepspeed.checkpoint.constants import OPTIMIZER_STATE_DICT, CLIP_GRAD
+
+import msamp
+from msamp.common.tensor import ScalingTensor, ScalingMeta
+from msamp.common.dtype import Dtypes
+from msamp.nn import model_state
+
+USING_FP32_MASTER_WEIGHT = bool(int(os.getenv('USING_FP32_MASTER_WEIGHT', 0)))
+if True:
+    # Mixed FP8 O2
+    if USING_FP32_MASTER_WEIGHT:
+        MASTER_WEIGHT_QTYPE = Dtypes.kfloat32
+    else:
+        MASTER_WEIGHT_QTYPE = Dtypes.kfloat16
+    WEIGHT_QTYPE = Dtypes.kfloat8_e4m3
+    WEIGHT_GRAD_QTYPE = Dtypes.kfloat8_e4m3
+else:
+    # Mixed FP8 O0
+    MASTER_WEIGHT_QTYPE = Dtypes.kfloat32
+    WEIGHT_QTYPE = Dtypes.kfloat16
+    WEIGHT_GRAD_QTYPE = Dtypes.kfloat16
+
+
+class FP8_Optimizer(DeepSpeedOptimizer):
+    """
+    FP8 Optimizer
+    """
+    def __init__(self,
+                 init_optimizer,
+                 deepspeed=None,
+                 static_loss_scale=1.0,
+                 dynamic_loss_scale=False,
+                 initial_dynamic_scale=2**32,
+                 dynamic_loss_args=None,
+                 verbose=True,
+                 mpu=None,
+                 clip_grad=0.0,
+                 fused_adam_legacy=False,
+                 has_moe_layers=False,
+                 timers=None):
+
+        self.fused_adam_legacy = fused_adam_legacy
+        self.timers = timers
+        self.deepspeed = deepspeed
+        self.has_moe_layers = has_moe_layers
+        self.using_pipeline = self.deepspeed.pipeline_parallelism if self.deepspeed is not None else None
+        if not torch.cuda.is_available():
+            raise SystemError("Cannot use fp16 without CUDA.")
+        self.optimizer = init_optimizer
+
+        # param flattened by groups
+        self.fp16_groups = []
+        self.fp16_groups_flat = []
+        self.fp32_groups_flat = []
+
+        # MSAMP
+        self.fp8_groups = []
+        self.fp8_master_groups = []
+
+        self._global_grad_norm = 0.
+
+        # Divide out FP8 param groups
+        # create FP8 weight and FP16 master weight
+        # Note: DO NOT CHANGE THE DICT OBJECT IN PARAM_GROUPS SINCE LR_SCHEDULER WILL CHANGE THEIR LR
+        for i, param_group in enumerate(self.optimizer.param_groups):
+            fp8_pg = dict((k, v) for k, v in param_group.items() if k != 'params')
+            fp8_params = []  # weight
+            fp8_master_params = []  # master weight
+            fp16_params = []
+            for p in param_group['params']:
+                if isinstance(p, ScalingTensor):
+                    # FP8 Tensor
+                    # high-precision param
+                    master_weight = p.clone().cast(MASTER_WEIGHT_QTYPE)
+                    master_weight.requires_grad = True
+                    master_weight._param_name = getattr(p, '_param_name', '')
+                    # low-precision param
+                    p.data = p.data.cast(WEIGHT_QTYPE)
+                    fp8_params.append(p)
+                    fp8_master_params.append(master_weight)
+                else:
+                    # torch.Tensor
+                    fp16_params.append(p)
+
+            self.fp16_groups.append(fp16_params)
+            # init fp16 weight buffer, flattened
+            self.fp16_groups_flat.append(
+                _flatten_dense_tensors([p.clone().detach()
+                                        for p in self.fp16_groups[i]]))
+            # set model fp16 weight to slices of flattened buffer
+            updated_params = _unflatten_dense_tensors(self.fp16_groups_flat[i],
+                                                      self.fp16_groups[i])
+            for p, q in zip(self.fp16_groups[i], updated_params):
+                p.data = q.data
+
+            # init fp32 master weight, flattened
+            self.fp32_groups_flat.append(
+                self.fp16_groups_flat[i].clone().float().detach())
+            # modify optimizer of have flat master weight
+            self.fp32_groups_flat[
+                i].requires_grad = True  # keep this in case internal optimizer uses it
+
+            # FP8
+            self.fp8_groups.append(fp8_params)
+            self.fp8_master_groups.append(fp8_master_params)
+
+            # update param group
+            param_group['params'] = [self.fp32_groups_flat[i]] + fp8_master_params
+
+        # we may have a way of fusing dynamic scale. Do not support for now
+        if dynamic_loss_scale:
+            self.dynamic_loss_scale = True
+            self.cur_iter = 0
+            self.last_overflow_iter = -1
+            self.scale_factor = 2
+
+            if dynamic_loss_args is None:
+                self.cur_scale = initial_dynamic_scale
+                self.scale_window = 1000
+                self.min_loss_scale = 1
+            else:
+                self.cur_scale = dynamic_loss_args[INITIAL_LOSS_SCALE]
+                self.scale_window = dynamic_loss_args[SCALE_WINDOW]
+                self.min_loss_scale = dynamic_loss_args[MIN_LOSS_SCALE]
+        else:
+            self.dynamic_loss_scale = False
+            self.cur_iter = 0
+            self.cur_scale = static_loss_scale
+        self.verbose = verbose
+
+        self.custom_loss_scaler = False
+        self.external_loss_scale = None
+
+        self.clip_grad = clip_grad
+        self.norm_type = 2
+        self.step_count = 0
+
+        TORCH_MAJOR = int(torch.__version__.split('.')[0])
+        TORCH_MINOR = int(torch.__version__.split('.')[1])
+        self.clip_grad_norm = msamp.nn.clip_grad_norm_
+
+        #model parallel object
+        self.mpu = mpu
+
+        self.overflow = False
+        self.overflow_checker = CheckOverflow(self.fp16_groups + self.fp8_groups,
+                                              mpu=self.mpu,
+                                              deepspeed=deepspeed)
+        self.initialize_optimizer_states()
+
+    def initialize_optimizer_states(self):
+        # optimizer.step() may change the parameters (like l2_reg).
+        return
+        for i, group in enumerate(self.fp16_groups):
+            self.fp32_groups_flat[i].grad = torch.zeros(
+                self.fp32_groups_flat[i].size(),
+                device=self.fp32_groups_flat[i].device)
+
+        for pg in self.fp8_master_groups:
+            for p in pg:
+                p.grad = ScalingTensor(
+                    p.value.new_zeros(p.shape, dtype=torch.uint8),
+                    ScalingMeta(WEIGHT_GRAD_QTYPE),
+                )
+
+        self.optimizer.step()
+
+        for i, group in enumerate(self.fp16_groups):
+            self.fp32_groups_flat[i].grad = None
+
+        for pg in self.fp8_master_groups:
+            for p in pg:
+                p.grad = None
+
+    def zero_grad(self, set_grads_to_None=True):
+        """
+        Zero FP16 parameter grads.
+        """
+        # For speed, set model fp16 grad to None by default
+        for group in self.fp16_groups + self.fp8_groups:
+            for p in group:
+                if set_grads_to_None:
+                    p.grad = None
+                else:
+                    if p.grad is not None:
+                        p.grad.detach_()
+                        p.grad.zero_()
+
+    def step_fused_adam(self, closure=None):
+        """
+        Not supporting closure.
+        """
+        raise NotImplementedError('[TODO] support ScalingTensor')
+
+    def start_timers(self, name_list):
+        if self.timers is not None:
+            for name in name_list:
+                self.timers(name).start()
+
+    def stop_timers(self, name_list):
+        if self.timers is not None:
+            for name in name_list:
+                self.timers(name).stop()
+
+    def log_timers(self, name_list):
+        if self.timers is not None:
+            self.timers.log(name_list)
+
+    def set_lr(self, lr):
+        """Set the learning rate."""
+        for param_group in self.optimizer.param_groups:
+            param_group["lr"] = lr
+
+    def get_lr(self):
+        """Return the current learning rate."""
+        return self.optimizer.param_groups[0]["lr"]
+
+    def override_loss_scale(self, loss_scale):
+        if loss_scale != self.external_loss_scale:
+            logger.info(
+                f'[deepspeed] setting loss scale from {self.external_loss_scale} -> {loss_scale}'
+            )
+        self.custom_loss_scaler = True
+        self.external_loss_scale = loss_scale
+
+    def step(self, closure=None):
+        """
+        Not supporting closure.
+        """
+
+        if self.fused_adam_legacy:
+            return self.step_fused_adam()
+
+        COMPUTE_NORM = "compute_norm"
+        OVERFLOW_CHECK = 'overflow_check'
+        OVERFLOW_TIMERS = [COMPUTE_NORM, OVERFLOW_CHECK]
+        UNSCALE_AND_CLIP = 'unscale_and_clip'
+        BASIC_STEP = 'basic_step'
+        UPDATE_FP16 = 'update_fp16'
+        STEP_TIMERS = OVERFLOW_TIMERS + [UNSCALE_AND_CLIP, BASIC_STEP, UPDATE_FP16]
+
+        # First determine if there is overflow.
+        self.start_timers([OVERFLOW_CHECK])
+        fp16_params = []
+        for i, group in enumerate(self.fp16_groups):
+            fp16_params.extend([p for p in group if p.grad is not None])
+
+        fp8_params = []
+        for i, group in enumerate(self.fp8_groups):
+            fp8_params.extend([p for p in group if p.grad is not None])
+
+        self.overflow = self.overflow_checker.has_overflow(fp16_params + fp8_params)
+        self.stop_timers([OVERFLOW_CHECK])
+        prev_scale = self.cur_scale
+        self._update_scale(self.overflow)
+        if self.overflow:
+            if self.verbose:
+                log_dist(
+                    "Overflow detected. Skipping step. Attempted loss "
+                    f"scale: {prev_scale}, reducing to {self.cur_scale}",
+                    ranks=[0])
+            # Clear gradients
+            for i, group in enumerate(self.fp16_groups + self.fp8_groups):
+                for p in group:
+                    p.grad = None
+
+            self.log_timers(OVERFLOW_TIMERS)
+            return self.overflow
+
+        # move weight.grad to master_weight.grad
+        grads_groups_flat = []
+        for i, group in enumerate(self.fp16_groups):
+            data_type = self.fp32_groups_flat[i].dtype
+
+            grads_groups_flat.append(
+                _flatten_dense_tensors([
+                    torch.zeros(p.size(),
+                                dtype=data_type,
+                                device=p.device)
+                    if p.grad is None else p.grad.to(data_type) for p in group
+                ]))
+
+            for p in group:
+                p.grad = None
+
+            self.fp32_groups_flat[i].grad = grads_groups_flat[i]
+
+        # FP8
+        assert len(self.fp8_groups) == len(self.fp8_master_groups)
+        for ps, master_ps in zip(self.fp8_groups, self.fp8_master_groups):
+            assert len(ps) == len(master_ps)
+            for p, m in zip(ps, master_ps):
+                m.grad = p.grad
+                p.grad = None
+
+
+        self.start_timers([COMPUTE_NORM])
+        fp8_groups_flat = list(chain.from_iterable(self.fp8_master_groups))
+
+        all_groups_norm = get_grad_norm(self.fp32_groups_flat + fp8_groups_flat, mpu=self.mpu)
+
+        self.stop_timers([COMPUTE_NORM])
+
+        if self.has_moe_layers:
+            all_groups_norm = self._get_norm_with_moe_layers(all_groups_norm)
+
+        scaled_global_grad_norm = get_global_norm(norm_list=[all_groups_norm])
+
+        # the gradients are not unscaled.
+
+        # Stash unscaled gradient norm
+        self._global_grad_norm = scaled_global_grad_norm / self.cur_scale
+
+        self.start_timers([UNSCALE_AND_CLIP])
+
+        # grad has been moved into master
+        fp8_master_grads = [p.grad for p in fp8_groups_flat]
+        self.unscale_and_clip_grads(grads_groups_flat + fp8_master_grads,
+                                    scaled_global_grad_norm)
+
+        self.stop_timers([UNSCALE_AND_CLIP])
+
+        self.start_timers([BASIC_STEP])
+        self.optimizer.step()
+        self.stop_timers([BASIC_STEP])
+
+        #get rid of the fp32 gradients. Not needed anymore
+        for group in self.fp32_groups_flat + fp8_groups_flat:
+            group.grad = None
+
+        self.start_timers([UPDATE_FP16])
+
+        # copy master params to params
+        for i in range(len(self.fp16_groups)):
+            updated_params = _unflatten_dense_tensors(self.fp32_groups_flat[i],
+                                                      self.fp16_groups[i])
+            for p, q in zip(self.fp16_groups[i], updated_params):
+                p.data.copy_(q.data)
+
+        for ps, master_ps in zip(self.fp8_groups, self.fp8_master_groups):
+            for p, m in zip(ps, master_ps):
+                # weight consists of ref ScalingMeta
+                p.data = m.data.cast(WEIGHT_QTYPE)
+
+        self.stop_timers([UPDATE_FP16])
+
+        self.log_timers(STEP_TIMERS)
+
+        self.step_count += 1
+
+        return self.overflow
+
+    def _get_norm_with_moe_layers(self, all_groups_norm):
+        #all_groups_norm_old = all_groups_norm
+        # Need to allreduce (avg) the norms across different ranks because moe params will not be synced during allreduce
+        if self.using_pipeline:
+            pg = self.deepspeed.mpu.get_data_parallel_group()
+        else:
+            pg = groups._get_data_parallel_group()
+        scaled_norm = all_groups_norm * 1.0 / float(dist.get_world_size(group=pg))
+        scaled_norm_tensor = torch.tensor(scaled_norm,
+                                          device=self.fp32_groups_flat[0].device,
+                                          dtype=torch.float)
+        dist.all_reduce(scaled_norm_tensor, group=pg)
+        all_groups_norm = scaled_norm_tensor.item()
+        #print(f"old = {all_groups_norm_old} and new = {all_groups_norm} at rank: {deepspeed.comm.get_rank()}")
+        return all_groups_norm
+
+    def unscale_and_clip_grads(self, grad_groups_flat, total_norm, apply_scale=True):
+        # compute combined scale factor for this group
+        combined_scale = self.cur_scale
+        if self.clip_grad > 0.:
+            # norm is in fact norm*scale
+            clip = ((total_norm / self.cur_scale) + 1e-6) / self.clip_grad
+            if clip > 1:
+                combined_scale = clip * self.cur_scale
+
+        if apply_scale:
+            for grad in grad_groups_flat:
+                grad.data.mul_(1. / combined_scale)
+
+        return combined_scale
+
+    def backward(self, loss, create_graph=False, retain_graph=False):
+        """
+        :attr:`backward` performs the following steps:
+
+        1. fp32_loss = loss.float()
+        2. scaled_loss = fp32_loss*loss_scale
+        3. scaled_loss.backward(), which accumulates scaled gradients into the ``.grad`` attributes of the model's fp16 leaves
+        """
+        if self.custom_loss_scaler:
+            scaled_loss = self.external_loss_scale * loss
+            scaled_loss.backward()
+        else:
+            scaled_loss = (loss.float()) * self.cur_scale
+            scaled_loss.backward(create_graph=create_graph, retain_graph=retain_graph)
+
+    def _update_scale(self, skip):
+        if self.dynamic_loss_scale:
+            prev_scale = self.cur_scale
+            if skip:
+                self.cur_scale = max(self.cur_scale / self.scale_factor,
+                                     self.min_loss_scale)
+                self.last_overflow_iter = self.cur_iter
+                if self.verbose:
+                    logger.info(f"\nGrad overflow on iteration {self.cur_iter}")
+                    logger.info(
+                        f"Reducing dynamic loss scale from {prev_scale} to {self.cur_scale}"
+                    )
+            else:
+                # Ensure self.scale_window updates since last overflow
+                stable_interval = (self.cur_iter - self.last_overflow_iter) - 1
+                if (stable_interval > 0) and (stable_interval % self.scale_window == 0):
+                    self.cur_scale *= self.scale_factor
+                    if self.verbose:
+                        logger.info(
+                            f"No Grad overflow for {self.scale_window} iterations")
+                        logger.info(
+                            f"Increasing dynamic loss scale from {prev_scale} to {self.cur_scale}"
+                        )
+        else:
+            if skip:
+                logger.info("Grad overflow on iteration: %s", self.cur_iter)
+                logger.info("Using static loss scale of: %s", self.cur_scale)
+        self.cur_iter += 1
+        return
+
+    # Promote state so it can be retrieved or set via "fp16_optimizer_instance.state"
+    def _get_state(self):
+        return self.optimizer.state
+
+    def _set_state(self, value):
+        self.optimizer.state = value
+
+    state = property(_get_state, _set_state)
+
+    # Promote param_groups so it can be retrieved or set via "fp16_optimizer_instance.param_groups"
+    # (for example, to adjust the learning rate)
+    def _get_param_groups(self):
+        return self.optimizer.param_groups
+
+    def _set_param_groups(self, value):
+        self.optimizer.param_groups = value
+
+    param_groups = property(_get_param_groups, _set_param_groups)
+
+    def state_dict(self):
+        """
+        Returns a dict containing the current state of this :class:`FP16_Optimizer` instance.
+        This dict contains attributes of :class:`FP16_Optimizer`, as well as the state_dict
+        of the contained Pytorch optimizer.
+        Example::
+            checkpoint = {}
+            checkpoint['model'] = model.state_dict()
+            checkpoint['optimizer'] = optimizer.state_dict()
+            torch.save(checkpoint, "saved.pth")
+        """
+        state_dict = {}
+        state_dict['dynamic_loss_scale'] = self.dynamic_loss_scale
+        state_dict['cur_scale'] = self.cur_scale
+        state_dict['cur_iter'] = self.cur_iter
+        if state_dict['dynamic_loss_scale']:
+            state_dict['last_overflow_iter'] = self.last_overflow_iter
+            state_dict['scale_factor'] = self.scale_factor
+            state_dict['scale_window'] = self.scale_window
+        state_dict[OPTIMIZER_STATE_DICT] = self.optimizer.state_dict()
+        state_dict['fp32_groups_flat'] = self.fp32_groups_flat
+        state_dict['fp8_master_groups'] = self.fp8_master_groups
+        state_dict[CLIP_GRAD] = self.clip_grad
+        return state_dict
+
+    # Refresh fp32 master params from fp16 copies
+    def refresh_fp32_params(self):
+        for current, saved in zip(self.fp32_groups_flat, self.fp16_groups_flat):
+            current.data.copy_(saved.data)
+
+    def load_state_dict(self, state_dict, load_optimizer_states=True):
+        """
+        Loads a state_dict created by an earlier call to state_dict().
+        If ``fp16_optimizer_instance`` was constructed from some ``init_optimizer``,
+        whose parameters in turn came from ``model``, it is expected that the user
+        will call ``model.load_state_dict()`` before
+        ``fp16_optimizer_instance.load_state_dict()`` is called.
+        Example::
+            model = torch.nn.Linear(D_in, D_out).cuda().half()
+            optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
+            optimizer = FP16_Optimizer(optimizer, static_loss_scale = 128.0)
+            ...
+            checkpoint = torch.load("saved.pth")
+            model.load_state_dict(checkpoint['model'])
+            optimizer.load_state_dict(checkpoint['optimizer'])
+        """
+        # I think it should actually be ok to reload the optimizer before the model.
+        self.dynamic_loss_scale = state_dict['dynamic_loss_scale']
+        self.cur_scale = state_dict['cur_scale']
+        self.cur_iter = state_dict['cur_iter']
+        if state_dict['dynamic_loss_scale']:
+            self.last_overflow_iter = state_dict['last_overflow_iter']
+            self.scale_factor = state_dict['scale_factor']
+            self.scale_window = state_dict['scale_window']
+        if load_optimizer_states:
+            self.optimizer.load_state_dict(state_dict[OPTIMIZER_STATE_DICT])
+        self.clip_grad = state_dict[CLIP_GRAD]
+        # At this point, the optimizer's references to the model's fp32 parameters are up to date.
+        # The optimizer's hyperparameters and internal buffers are also up to date.
+        # However, the fp32 master copies of the model's fp16 params stored by the optimizer are still
+        # out of date.  There are two options.
+        # 1:  Refresh the master params from the model's fp16 params.
+        # This requires less storage but incurs precision loss.
+        # 2:  Save and restore the fp32 master copies separately.
+        # We choose option 2.
+        #
+        # Pytorch Optimizer.load_state_dict casts saved buffers (e.g. momentum) to the type and device
+        # of their associated parameters, because it's possible those buffers might not exist yet in
+        # the current optimizer instance.  In our case, as long as the current FP16_Optimizer has been
+        # constructed in the same way as the one whose state_dict we are loading, the same master params
+        # are guaranteed to exist, so we can just copy_() from the saved master params.
+        for current, saved in zip(self.fp32_groups_flat, state_dict['fp32_groups_flat']):
+            current.data.copy_(saved.data)
+
+        assert len(self.fp8_master_groups) == len(state_dict['fp8_master_groups'])
+        for ps, ms in zip(self.fp8_master_groups, state_dict['fp8_master_groups']):
+            assert len(ps) == len(ms)
+            for p, m in zip(ps, ms):
+                p.data.copy_(m.data)
+
+    def __repr__(self):
+        return repr(self.optimizer)
+
+    # Promote loss scale so it can be retrieved or set via "fp16_optimizer_instance.loss_scale"
+    def _get_loss_scale(self):
+        if self.custom_loss_scaler:
+            return self.external_loss_scale
+        else:
+            return self.cur_scale
+
+    def _set_loss_scale(self, value):
+        self.loss_scaler.cur_scale = value
+
+    loss_scale = property(_get_loss_scale, _set_loss_scale)

--- a/msamp/deepspeed/runtime/fp8/fused_optimizer.py
+++ b/msamp/deepspeed/runtime/fp8/fused_optimizer.py
@@ -4,9 +4,9 @@
 """MS-AMP FP8Optimizer."""
 
 from itertools import chain
+
 import torch
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
-
 from deepspeed import comm as dist
 from deepspeed.runtime import DeepSpeedOptimizer
 from deepspeed.runtime.utils import get_global_norm, get_grad_norm
@@ -49,7 +49,7 @@ class FP8Optimizer(DeepSpeedOptimizer):
             verbose (bool, optional): log verbose information. Defaults to True.
             mpu (MPU, optional): Model parallel unit. Defaults to None.
             clip_grad (float, optional): Gradient clipping. Defaults to 0.0.
-            fused_adam_legacy (bool, optional): Fused adam legacy. Defaults to False. Currenlty only support False.
+            fused_adam_legacy (bool, optional): Fused adam legacy. Defaults to False. Currently only support False.
             has_moe_layers (bool, optional): Has moe layers. Defaults to False.
             timers (Timers, optional): Timers. Defaults to None.
         """
@@ -443,7 +443,7 @@ class FP8Optimizer(DeepSpeedOptimizer):
         """Update the scale factor.
 
         Args:
-            overflow (bool): overflow or not. If overflow, current scale will be devided by scale factor, vice versa.
+            overflow (bool): overflow or not. If overflow, current scale will be divided by scale factor, vice versa.
         """
         if self.dynamic_loss_scale:
             prev_scale = self.cur_scale

--- a/msamp/deepspeed/runtime/utils.py
+++ b/msamp/deepspeed/runtime/utils.py
@@ -3,19 +3,24 @@
 
 """DeepSpeed Utils with MS-AMP support."""
 
+from deepspeed.runtime.utils import CheckOverflow
+
 from msamp.common.tensor import ScalingTensor
-# flake8: noqa: F403
-from deepspeed.runtime.utils import *
-
-_origin_CheckOverflow = CheckOverflow
 
 
-# flake8: noqa: F405
-class CheckOverflow(_origin_CheckOverflow):
+class MSAMPCheckOverflow(CheckOverflow):
     """CheckOverflow with MS-AMP support."""
     @staticmethod
     def _has_inf_or_nan(x, i):
-        """Check if the input tensor has inf or nan values."""
+        """Check if the input tensor has inf or nan values.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+            i (int): Index of the tensor.
+
+        Returns:
+            bool: True if the input tensor has inf or nan values.
+        """
         if isinstance(x, ScalingTensor):
             return x.has_inf_or_nan()
-        return _origin_CheckOverflow._has_inf_or_nan(x, i)
+        return CheckOverflow._has_inf_or_nan(x, i)

--- a/msamp/deepspeed/runtime/utils.py
+++ b/msamp/deepspeed/runtime/utils.py
@@ -6,7 +6,6 @@
 from msamp.common.tensor import ScalingTensor
 from deepspeed.runtime.utils import *
 
-
 _origin_CheckOverflow = CheckOverflow
 
 

--- a/msamp/deepspeed/runtime/utils.py
+++ b/msamp/deepspeed/runtime/utils.py
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""DeepSpeed Utils with MS-AMP support."""
+
+from msamp.common.tensor import ScalingTensor
+from deepspeed.runtime.utils import *
+
+
+_origin_CheckOverflow = CheckOverflow
+
+
+class CheckOverflow(_origin_CheckOverflow):
+    @staticmethod
+    def _has_inf_or_nan(x, i):
+        if isinstance(x, ScalingTensor):
+            return x.has_inf_or_nan()
+        return _origin_CheckOverflow._has_inf_or_nan(x, i)

--- a/msamp/deepspeed/runtime/utils.py
+++ b/msamp/deepspeed/runtime/utils.py
@@ -4,14 +4,18 @@
 """DeepSpeed Utils with MS-AMP support."""
 
 from msamp.common.tensor import ScalingTensor
+# flake8: noqa: F403
 from deepspeed.runtime.utils import *
 
 _origin_CheckOverflow = CheckOverflow
 
 
+# flake8: noqa: F405
 class CheckOverflow(_origin_CheckOverflow):
+    """CheckOverflow with MS-AMP support."""
     @staticmethod
     def _has_inf_or_nan(x, i):
+        """Check if the input tensor has inf or nan values."""
         if isinstance(x, ScalingTensor):
             return x.has_inf_or_nan()
         return _origin_CheckOverflow._has_inf_or_nan(x, i)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
     "pytest-cov>=4.0.0",
     "pytest>=7.2.0",
     "yapf>=0.32.0",
-    "deepspeed",
+    "deepspeed>=0.9.2",
     "mpi4py",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ test = [
     "pytest>=7.2.0",
     "yapf>=0.32.0",
     "deepspeed",
+    "mpi4py",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ classifiers=[
 dependencies = [
     "torch",
     "colorlog>=6.7.0",
+    "deepspeed>=0.9.2",
+    "mpi4py",
 ]
 dynamic = ["version"]
 
@@ -51,8 +53,6 @@ test = [
     "pytest-cov>=4.0.0",
     "pytest>=7.2.0",
     "yapf>=0.32.0",
-    "deepspeed>=0.9.2",
-    "mpi4py",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ test = [
     "pytest-cov>=4.0.0",
     "pytest>=7.2.0",
     "yapf>=0.32.0",
+    "deepspeed",
 ]
 
 [project.urls]

--- a/tests/deepspeed/test_engine.py
+++ b/tests/deepspeed/test_engine.py
@@ -1,0 +1,177 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for deepspeed engine with MS-AMP."""
+
+import unittest
+import torch
+import torch.nn as nn
+
+from deepspeed.ops.adam import FusedAdam
+from deepspeed.runtime.fp16.fused_optimizer import FP16_Optimizer
+
+from msamp import deepspeed
+from msamp.common.dtype.dtypes import Dtypes
+from msamp.optim import LBAdam, LBAdamW, DSAdam
+from msamp.deepspeed.runtime.engine import split_half_float_double_sparse
+from msamp.deepspeed.runtime.fp8.fused_optimizer import FP8Optimizer
+from msamp.nn import LinearReplacer
+from tests.helper import decorator
+
+
+class DeepSpeedEngineTestCase(unittest.TestCase):
+    """Test MSAMPDeepSpeedEngine."""
+    def setUp(self):
+        """Hook method for setting up the test fixture before exercising it."""
+        torch.manual_seed(1000)
+
+    def tearDown(self):
+        """Hook method for deconstructing the test fixture after testing it."""
+        pass
+
+    @decorator.cuda_test
+    def test_split_half_float_double_sparse(self):
+        """Test split_half_float_double_sparse method."""
+        tensors = []
+
+        dtype_list = [torch.float32, torch.float16, torch.float64, torch.bfloat16]
+
+        size_list = [3, 4, 5, 6]
+
+        for i, size in enumerate(size_list):
+            for _ in range(size):
+                tensor = torch.randn(2, 2, dtype=dtype_list[i], device='cuda')
+                tensors.append(tensor)
+
+        num_scaling_tensor = 7
+        for i in range(num_scaling_tensor):
+            tensor = torch.randn(2, 2, dtype=torch.float32, device='cuda').cast(Dtypes.kfloat8_e4m3)
+            tensors.append(tensor)
+        buckets = split_half_float_double_sparse(tensors)
+
+        assert len(buckets) == 5
+
+        has_scaling_tensor = False
+        for dtype, bucket in buckets:
+            if dtype == 'msamp.common.tensor.tensor.ScalingTensor':
+                assert len(bucket) == num_scaling_tensor
+                has_scaling_tensor = True
+        assert has_scaling_tensor
+
+    @decorator.cuda_test
+    def test_config_optimizer(self):
+        """Test config optimizer."""
+        model = nn.Linear(4, 4, device='cuda')
+
+        # Don't specify optimizer in config.
+        config = {
+            'train_batch_size': 1,
+        }
+        model1, _, _, _ = deepspeed.initialize(model=model, config=config)
+        assert model1.basic_optimizer is None
+        assert model1.optimizer is None
+
+        # adam + FP32.
+        config = {
+            'train_batch_size': 1,
+            'optimizer': {
+                'type': 'adam',
+            }
+        }
+
+        model2, _, _, _ = deepspeed.initialize(model=model, config=config)
+        assert isinstance(model2.basic_optimizer, FusedAdam)
+        assert model2.basic_optimizer == model2.optimizer
+
+        # adam + FP16.
+        config = {
+            'train_batch_size': 1,
+            'optimizer': {
+                'type': 'adam'
+            },
+            'fp16': {
+                'enabled': True,
+            }
+        }
+
+        model3, _, _, _ = deepspeed.initialize(model=model, config=config)
+        assert isinstance(model3.basic_optimizer, FusedAdam)
+        assert isinstance(model3.optimizer, FP16_Optimizer)
+
+        # DSAdam
+        config = {
+            'train_batch_size': 1,
+            'optimizer': {
+                'type': 'msamp_adam',
+            }
+        }
+        model4, _, _, _ = deepspeed.initialize(model=model, config=config)
+
+        assert isinstance(model4.basic_optimizer, DSAdam)
+        assert isinstance(model4.optimizer, FP8Optimizer)
+
+        # LBAdam
+        config = {
+            'train_batch_size': 1,
+            'optimizer': {
+                'type': 'msamp_adam',
+                'params': {
+                    'torch_adam': True,
+                    'adam_w_mode': False,
+                }
+            }
+        }
+
+        model5, _, _, _ = deepspeed.initialize(model=model, config=config)
+
+        assert isinstance(model5.basic_optimizer, LBAdam)
+        assert isinstance(model5.optimizer, FP8Optimizer)
+
+        # LBAdamW
+        config = {
+            'train_batch_size': 1,
+            'optimizer': {
+                'type': 'msamp_adamw',
+                'params': {
+                    'torch_adam': True,
+                }
+            }
+        }
+
+        model6, _, _, _ = deepspeed.initialize(model=model, config=config)
+
+        assert isinstance(model6.basic_optimizer, LBAdamW)
+        assert isinstance(model6.optimizer, FP8Optimizer)
+
+    @decorator.cuda_test
+    def test_backward(self):
+        """test backward method."""
+        model = nn.Linear(4, 4, device='cuda')
+        model = LinearReplacer.replace(model, Dtypes.kfloat16)
+        optimizer = LBAdamW(list(model.parameters()))
+
+        config = {
+            'train_batch_size': 1,
+        }
+        model, optimizer, _, _ = deepspeed.initialize(model=model, optimizer=optimizer, config=config)
+
+        inputs = []
+        num_inputs = 10
+        for _ in range(num_inputs):
+            inputs.append(torch.rand(4, 4, device='cuda'))
+
+        losses = []
+        epoches = 10
+        for _ in range(epoches):
+            loss = 0
+            for i in range(num_inputs):
+                output = model(inputs[i])
+                loss += output.sum()
+                model.backward(loss)
+                model.step()
+            loss /= 10
+            losses.append(loss)
+
+        for i in range(epoches):
+            if i > 0:
+                assert losses[i] < losses[i - 1]

--- a/tests/deepspeed/test_engine.py
+++ b/tests/deepspeed/test_engine.py
@@ -4,9 +4,9 @@
 """Tests for deepspeed engine with MS-AMP."""
 
 import unittest
+
 import torch
 import torch.nn as nn
-
 from deepspeed.ops.adam import FusedAdam
 from deepspeed.runtime.fp16.fused_optimizer import FP16_Optimizer
 
@@ -145,7 +145,7 @@ class DeepSpeedEngineTestCase(unittest.TestCase):
 
     @decorator.cuda_test
     def test_backward(self):
-        """test backward method."""
+        """Test backward method."""
         model = nn.Linear(4, 4, device='cuda')
         model = LinearReplacer.replace(model, Dtypes.kfloat16)
         optimizer = LBAdamW(list(model.parameters()))

--- a/tests/deepspeed/test_initialize.py
+++ b/tests/deepspeed/test_initialize.py
@@ -4,17 +4,15 @@
 """Tests for deepspeed initialize with MS-AMP."""
 
 import unittest
+
 import torch
 import torch.nn as nn
-
 from deepspeed.runtime.pipe.engine import PipelineEngine
 from deepspeed.runtime.hybrid_engine import DeepSpeedHybridEngine
-
 from deepspeed.pipe import PipelineModule
 
 from msamp import deepspeed
 from msamp.deepspeed.runtime.engine import MSAMPDeepSpeedEngine
-
 from tests.helper import decorator
 
 

--- a/tests/deepspeed/test_initialize.py
+++ b/tests/deepspeed/test_initialize.py
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for deepspeed initialize with MS-AMP."""
+
+import unittest
+import torch
+import torch.nn as nn
+
+from deepspeed.runtime.pipe.engine import PipelineEngine
+from deepspeed.runtime.hybrid_engine import DeepSpeedHybridEngine
+
+from deepspeed.pipe import PipelineModule
+
+from msamp import deepspeed
+from msamp.deepspeed.runtime.engine import MSAMPDeepSpeedEngine
+
+from tests.helper import decorator
+
+
+class DeepSpeedInitializeTestCase(unittest.TestCase):
+    """Test DeepSpeed.initialize with MS-AMP."""
+    def setUp(self):
+        """Hook method for setting up the test fixture before exercising it."""
+        torch.manual_seed(1000)
+
+    def tearDown(self):
+        """Hook method for deconstructing the test fixture after testing it."""
+        pass
+
+    @decorator.cuda_test
+    def test_initialize(self):
+        """Test DeepSpeed.initialize method."""
+        model1 = torch.nn.Linear(4, 4)
+        config = {
+            'train_batch_size': 1,
+        }
+        model1, _, _, _ = deepspeed.initialize(model=model1, config=config)
+        assert isinstance(model1, MSAMPDeepSpeedEngine)
+
+        model2 = nn.Sequential(nn.Linear(4, 10), nn.ReLU(inplace=True), nn.Linear(10, 4))
+
+        model2 = PipelineModule(layers=model2, num_stages=1)
+        model2, _, _, _ = deepspeed.initialize(model=model2, config=config)
+        assert isinstance(model2, PipelineEngine)
+
+        config = {'train_batch_size': 1, 'hybrid_engine': {'enabled': True}}
+        model3 = torch.nn.Linear(4, 4)
+        model3, _, _, _ = deepspeed.initialize(model=model3, config=config)
+        assert isinstance(model3, DeepSpeedHybridEngine)

--- a/tests/deepspeed/test_optimizer.py
+++ b/tests/deepspeed/test_optimizer.py
@@ -21,6 +21,7 @@ class DeepSpeedTestCase(unittest.TestCase):
 
     @decorator.cuda_test
     def test_fused_optimizer(self):
+        """Test fused optimizer."""
         input = torch.randn(4, 4, device='cuda')
         model = torch.nn.Linear(4, 4, bias=False).cuda()
         model1 = LinearReplacer.replace(model, Dtypes.kfloat16)

--- a/tests/deepspeed/test_optimizer.py
+++ b/tests/deepspeed/test_optimizer.py
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for deepspeed optimizer with MS-AMP."""
+
+import unittest
+import torch
+
+from tests.helper import decorator
+from msamp import deepspeed
+from msamp.optim import LBAdamW
+
+
+class DeepSpeedTestCase(unittest.TestCase):
+    """Test functions in deepspeed optimizer with MS-AMP."""
+    def setUp(self):
+        """Hook method for setting up the test fixture before exercising it."""
+        torch.manual_seed(1000)
+
+    @decorator.cuda_test
+    def test_fused_optimizer(self):
+        input = torch.randn(4, 4, device='cuda')
+        model = torch.nn.Linear(4, 4, bias=False).cuda()
+        model1 = LinearReplacer.replace(model, Dtypes.kfloat16)
+        model2 = LinearReplacer.replace(model, Dtypes.kfloat16)
+        assert torch.all(model1.weight.float(), model2.weight.float())
+        opt1 = LBAdamW(list(model1.parameters()))
+        opt2 = LBAdamW(list(model2.parameters()))
+
+        config = {
+            'train_batch_size': 1,
+            'train_micro_batch_size_per_gpu': 1,
+        }
+
+        model2, opt2, _, _ = deepspeed.initialize(
+            model=model2,
+            optimizer=opt2,
+            dist_init_required=False,
+            config=config,
+        )
+
+        model1(input).sum().backward()
+        opt1.step()
+        model2.backward(model2(input).sum())
+        model2.step()
+        assert torch.all(model1.weight.float(), model2.weight.float())

--- a/tests/deepspeed/test_optimizer.py
+++ b/tests/deepspeed/test_optimizer.py
@@ -3,6 +3,7 @@
 
 """Tests for deepspeed optimizer with MS-AMP."""
 
+import os
 import unittest
 import torch
 
@@ -10,14 +11,21 @@ from msamp import deepspeed
 from msamp.common.dtype import Dtypes
 from msamp.nn import LinearReplacer
 from msamp.optim import LBAdamW
+from msamp.deepspeed.runtime.fp8.fused_optimizer import FP8Optimizer
 from tests.helper import decorator
 
 
-class DeepSpeedTestCase(unittest.TestCase):
+class FP8OptimizerTestCase(unittest.TestCase):
     """Test functions in deepspeed optimizer with MS-AMP."""
     def setUp(self):
         """Hook method for setting up the test fixture before exercising it."""
         torch.manual_seed(1000)
+        self.checkpoint_path = 'model.pth'
+
+    def tearDown(self):
+        """Hook method for deconstructing the test fixture after testing it."""
+        if os.path.exists(self.checkpoint_path):
+            os.remove(self.checkpoint_path)
 
     @decorator.cuda_test
     def test_fused_optimizer(self):
@@ -48,3 +56,42 @@ class DeepSpeedTestCase(unittest.TestCase):
         model2.backward(model2(input).sum())
         model2.step()
         assert torch.equal(model1.weight.cast(Dtypes.kfloat8_e4m3).float(), model2.weight.float())
+
+    @decorator.cuda_test
+    def test_state_dict(self):
+        """Test state dict."""
+        model1 = torch.nn.Linear(4, 4).cuda()
+        model1 = LinearReplacer.replace(model1, Dtypes.kfloat16)
+        optimizer1 = LBAdamW(list(model1.parameters()))
+        fp8_optimizer1 = FP8Optimizer(optimizer1, static_loss_scale=128.0)
+
+        for _ in range(10):
+            input = torch.randn(4, 4, device='cuda')
+            loss = model1(input).sum()
+            loss.backward()
+            optimizer1.step()
+
+        checkpoint1 = {}
+        checkpoint1['model'] = model1.state_dict()
+        checkpoint1['optimizer'] = fp8_optimizer1.state_dict()
+        torch.save(checkpoint1, self.checkpoint_path)
+
+        model2 = torch.nn.Linear(4, 4).cuda()
+        model2 = LinearReplacer.replace(model2, Dtypes.kfloat16)
+        optimizer2 = LBAdamW(list(model2.parameters()))
+        fp8_optimizer2 = FP8Optimizer(optimizer2, dynamic_loss_scale=True)
+        checkpoint2 = torch.load(self.checkpoint_path)
+        model2.load_state_dict(checkpoint2['model'])
+        fp8_optimizer2.load_state_dict(checkpoint2['optimizer'])
+
+        assert torch.equal(model1.weight.float(), model2.weight.float())
+        assert fp8_optimizer1.cur_scale == fp8_optimizer2.cur_scale
+
+        # check master groups
+        assert len(fp8_optimizer1.fp8_master_groups) == 1
+        assert len(fp8_optimizer2.fp8_master_groups) == 1
+
+        for i in range(len(fp8_optimizer1.fp8_master_groups[0])):
+            assert torch.equal(
+                fp8_optimizer1.fp8_master_groups[0][i].float(), fp8_optimizer2.fp8_master_groups[0][i].float()
+            )


### PR DESCRIPTION
**Description**
In this PR, DeepSpeed Optimizer with MS-AMP support is added.

The ZeRO Optimizer and Pipeline Parallelism will be added in the next PRs.

**Major Revision**
-  add deepspeed optimizer with MS-AMP support
- unit test for deepspeed optimizer

**Test in internal code**
In FP8Train, run the following script and get around 28.7% top-1 accuracy.
```python
python -m torch.distributed.launch --master_port 2253 --nproc_per_node 8 main.py --cfg configs/deit/deit_mini.yaml --data-path ./cifar100 --batch-size 128 --use-deepspeed --output ./cifar_checkpoints_deepspeed/test1 --opts TRAIN.USE_CHECKPOINT False DATA.DATASET CIFAR100 FP8.USE_FP8_LINEAR True
```