### PR TITLE
Support pytorch 2.1

### DIFF
--- a/examples/mnist_ddp.py
+++ b/examples/mnist_ddp.py
@@ -141,7 +141,7 @@ def main():
     )
     parser.add_argument('--save-model', action='store_true', default=False, help='For Saving the current Model')
 
-    parser.add_argument('--local_rank', type=int, help='local rank, will passed by ddp')
+    parser.add_argument('--local-rank', type=int, help='local rank, will passed by ddp')
 
     parser.add_argument('--enable-msamp', action='store_true', default=False, help='enable MS-AMP')
     parser.add_argument('--opt-level', type=str, default='O1', help='MS-AMP optimization level')

--- a/msamp/common/tensor/cast.py
+++ b/msamp/common/tensor/cast.py
@@ -53,6 +53,8 @@ class TypeCast:
             meta.qtype,
         )
 
+        # scale_inv will not be set to inverse of scale in torch 2.1
+        meta.scale_inv.data.copy_(torch.reciprocal(meta.scale))    # scale_inv = 1 / scale
         shape = input.shape
         return input_fp8.view(shape)
 

--- a/msamp/operators/gemm/gemm.py
+++ b/msamp/operators/gemm/gemm.py
@@ -115,8 +115,34 @@ class Gemm:
                 out = F.pad(out, (0, pM, 0, pN))
             assert out.is_cuda and out.is_contiguous()
 
+        out_scale = torch.ones_like(a_meta.scale)
+        out_max = torch.ones_like(a_meta.amax)
+        bias = (bias if bias is not None else cls._empty_tensor)
+
         # here out is padded, and src_out is the original one.
         if Device.is_fp8_supported():
+            """
+            void te_gemm(at::Tensor A,
+             at::Tensor A_scale_inverse,
+             transformer_engine::DType A_type,
+             bool transa,
+             at::Tensor B,
+             at::Tensor B_scale_inverse,
+             transformer_engine::DType B_type,
+             bool transb,
+             at::Tensor D,
+             at::Tensor D_scale,
+             transformer_engine::DType D_type,
+             at::Tensor D_amax,
+             at::Tensor bias,
+             transformer_engine::DType bias_type,
+             at::Tensor pre_gelu_out,
+             bool grad,
+             at::Tensor workspace,
+             size_t workspaceSize,
+             bool accumulate,
+             bool use_split_accumulator
+            """
             tew.te_gemm(
                 mat_a.value,
                 a_meta.scale_inv,
@@ -127,8 +153,11 @@ class Gemm:
                 b_meta.qtype,
                 False,    # transb
                 out,
+                out_scale,    # scale
                 out_qtype,
-                bias if bias is not None else cls._empty_tensor,
+                out_max,
+                bias,
+                Dtypes.dtype_to_qtype[bias.dtype],
                 cls._empty_tensor,
                 False,    # grad
                 workspace,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers=[
 ]
 dependencies = [
     "torch",
+    "transformer-engine>=0.7",
     "colorlog>=6.7.0",
     "deepspeed>=0.9.2",
     "mpi4py",


### PR DESCRIPTION
**Description**
The transformer-engine's version in pytorch 2.1 docker is different from the one in pytorch 1.14 docker. The API of cast_to_fp8 and te_gemm. What's more, there is a bug-fix in nccl to support pytorch 2.1.

**Major Revision**
- Upgrade transformer engine to v0.7
- Upgrade nccl to latest commit
- Adapt to new API of transformer engine
