### PR TITLE
[WIP] DistributedDataParallel with FP8-support

### DIFF
--- a/examples/mnist_ddp.py
+++ b/examples/mnist_ddp.py
@@ -70,8 +70,6 @@ def train(args, model, device, train_loader, optimizer, epoch):
             output = model(data)
         loss = F.nll_loss(output, target)
         scaler.scale(loss).backward()
-        if hasattr(optimizer, 'all_reduce_grads'):
-            optimizer.all_reduce_grads(model)
         scaler.step(optimizer)
         scaler.update()
         if dist.get_rank() == 0:

--- a/msamp/deepspeed/runtime/engine.py
+++ b/msamp/deepspeed/runtime/engine.py
@@ -355,9 +355,6 @@ class MSAMPDeepSpeedEngine(DeepSpeedEngine):
 
         if allreduce_gradients and self.enable_backward_allreduce:
             # Traditional code path that allreduces the module parameter grads
-            # It will not call optimizer.all_reduce_grads so we set ready_to_all_reduce_grads to False.
-            # In optimizer.step, ready_to_all_reduce_grads is supposed to be False.
-            model_state.ready_to_all_reduce_grads = False
             self.allreduce_gradients()
 
         self._stop_timers(self.engine_timers.backward_reduce_timers)

--- a/msamp/nn/__init__.py
+++ b/msamp/nn/__init__.py
@@ -9,6 +9,7 @@ from msamp.nn.state import model_state
 from msamp.nn.linear import FP8Linear, LinearReplacer
 from msamp.nn import functional
 from msamp.nn.clip_grad import clip_grad_norm_
+from msamp.nn import parallel
 del functional
 
 __all__ = ['ScalingParameter', 'ScalingModule', 'model_state', 'FP8Linear', 'LinearReplacer', 'clip_grad_norm_']

--- a/msamp/nn/functional.py
+++ b/msamp/nn/functional.py
@@ -98,11 +98,8 @@ class _FP8GemmFunction(torch.autograd.Function):
                 )
                 del old_wgrad
 
-            # wgrad above this line is torch.Tensor w/o tensor scaling
-            wgrad = wgrad.cast(Dtypes.kfloat8_e4m3, meta=wgrad_meta, sync=True)
-            if DistUtil.get_world_size() > 1:
-                model_state.ready_to_all_reduce_grads = True
-
+            # set meta for wgrad
+            wgrad.meta = wgrad_meta
             ctx.weight.backward_grad_update(wgrad)
 
         return input_grad, None, None, None

--- a/msamp/nn/linear.py
+++ b/msamp/nn/linear.py
@@ -179,9 +179,8 @@ class LinearReplacer:
         for k, p in fp8_named_weights:
             p._param_name = k
 
-        # DDP ignores the FP8 weights, and the optimizer provides a function `optimizer.all_reduce_grads(model)`
-        # to sync them.
+        # the native DDP ignores the FP8 weights,
+        # and msamp.nn.parallel.distributed.DistributedDataParallel handles them.
         torch.nn.parallel.DistributedDataParallel._set_params_and_buffers_to_ignore_for_model(model, fp8_names)
-
         model_state.register_scaling_metas(model)
         return model

--- a/msamp/nn/parallel/__init__.py
+++ b/msamp/nn/parallel/__init__.py
@@ -1,0 +1,1 @@
+from .distributed import DistributedDataParallel

--- a/msamp/nn/parallel/distributed.py
+++ b/msamp/nn/parallel/distributed.py
@@ -154,7 +154,7 @@ class _DDPSink(torch.autograd.Function):
     def forward(ctx, reducer, *inputs):
         ctx.set_materialize_grads(False)
         ctx.reducer = reducer
-        reducer.scaling_tensor_reducer.reset_buckets()
+        reducer.reset_buckets()
         return inputs
     @staticmethod
     def backward(ctx, *grad_outputs):

--- a/msamp/nn/parallel/distributed.py
+++ b/msamp/nn/parallel/distributed.py
@@ -1,0 +1,152 @@
+import math
+import torch
+from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
+import torch.distributed as dist
+from msamp.common.tensor import ScalingTensor, ScalingMeta
+from msamp.common.dtype import Dtypes, Floating
+from msamp.common.utils import TransformerEngineWrapper
+from msamp.operators.dist_op import DistOp
+
+
+class ScalingTensorReducer:
+    def __init__(self, parameters, process_group, bucket_bytes_cap):
+        parameters = list(parameters)
+        if not all(isinstance(p, ScalingTensor) for p in parameters):
+            raise ValueError("All parameters must be ScalingTensor")
+        # check the devices of parameters are the same
+        if not all(p.device == parameters[0].device for p in parameters):
+            raise ValueError("All parameters must be on the same device")
+        self.device = parameters[0].device
+        self.parameters = parameters
+        self.param_to_id = {p: i for i, p in enumerate(parameters)}
+        self.bucket_bytes_cap = bucket_bytes_cap
+        self.process_group = process_group
+        self._build_buckets(parameters)
+        self._register_backward_hooks()
+        self.bucket_unreduced_param_ids = dict()
+
+    def get_param_id(self, param):
+        return self.param_to_id[param]
+
+    def _build_buckets(self, parameters):
+        bucket_bytes = 0
+        total_bytes = 0
+        bucket_id = 0
+        bucket_offset = 0
+        param_id_to_bucket_id = {}
+        bucket_to_param_ids = {}
+        bucket_to_range = {}
+        for p in parameters[::-1]:
+            param_id = self.get_param_id(p)
+            nbytes = p.numel()
+            param_id_to_bucket_id[param_id] = bucket_id
+            bucket_to_param_ids.setdefault(bucket_id, []).append(param_id)
+            bucket_bytes += nbytes
+            total_bytes += nbytes
+            if bucket_bytes >= self.bucket_bytes_cap:
+                bucket_to_range[bucket_id] = (bucket_offset, bucket_offset + bucket_bytes)
+                bucket_id += 1
+                bucket_bytes = 0
+
+        # the last bucket, if not empty
+        if bucket_bytes > 0:
+            bucket_to_range[bucket_id] = (bucket_offset, bucket_offset + bucket_bytes)
+        self.param_id_to_bucket_id = param_id_to_bucket_id
+        self.bucket_to_param_ids = bucket_to_param_ids
+        self.bucket_to_range = bucket_to_range
+
+    def reset_buckets(self):
+        if len(self.bucket_unreduced_param_ids) > 0:
+            raise RuntimeError("some gradients are not reduced: {}".format(list(self.bucket_unreduced_param_ids.keys())))
+        self.bucket_unreduced_param_ids = {k: set(v) for k, v in self.bucket_to_param_ids.items()}
+
+    def _register_backward_hooks(self):
+        for p in self.parameters:
+            p.register_backward_post_hook(self._get_backward_hook(p))
+
+    def _get_backward_hook(self, param):
+        param_id = self.get_param_id(param)
+        bucket_id = self.param_id_to_bucket_id[param_id]
+        def hook_fn(*args, **kwargs):
+            unreduced_param_ids = self.bucket_unreduced_param_ids[bucket_id]
+            try:
+                unreduced_param_ids.remove(param_id)
+            except KeyError:
+                raise RuntimeError("gradient is already reduced")
+            if len(unreduced_param_ids) == 0:
+                # the bucket is full, reduce it
+                self._reduce_bucket(bucket_id)
+                self.bucket_unreduced_param_ids.pop(bucket_id)
+        return hook_fn
+
+    def _reduce_bucket(self, bucket_id):
+        # step 1: collect the gradients
+        param_ids = self.bucket_to_param_ids[bucket_id]
+        params = [self.parameters[i] for i in param_ids]
+        grads = [p.grad for p in params]
+        metas = [g.meta for g in grads]
+
+        # step 2: synchronize the amax
+        # shape of amaxs: (n, )
+        amaxs = torch.stack([g.max().float() for g in grads])
+        scales = torch.stack([meta.scale for meta in metas])
+        # convert NAN to INF since NCCL-ReduceMax ignores NAN
+        # notice: nan and posinf must be INF
+        amaxs.nan_to_num_(nan=torch.inf, posinf=torch.inf)
+        dist.all_reduce(amaxs, op=dist.ReduceOp.MAX, group=self.process_group)
+
+        # step 3: update scaling factor
+        wgrad_qtype = Dtypes.kfloat8_e4m3
+        fp_max = Floating.qfp_max[wgrad_qtype]
+        world_size = dist.get_world_size(self.process_group)
+        pre_scale = 1.0 / math.sqrt(world_size)
+        # shape of sf: (n, )
+        sf = ScalingMeta.compute_scaling_factor(amaxs, scales, fp_max, margin=0)
+        sf.mul_(pre_scale)
+
+        for meta, amax, scale in zip(metas, amaxs, sf):
+            meta.amax[0] = amax
+            if torch.isfinite(scale):
+                meta.scale.copy_(scale)
+
+        # step 4: quantize the gradients to FP8
+        dummy_amax = torch.empty((1, ), dtype=torch.float32, device=self.device)
+        bucket_range = self.bucket_to_range[bucket_id]
+        bucket_offset = bucket_range[0]
+        fp8_grads = []
+        for i, (grad, meta) in enumerate(zip(grads, metas)):
+            fp8_grad = TransformerEngineWrapper.cast_to_fp8(
+                grad.view(1, -1),
+                meta.scale,
+                dummy_amax,
+                meta.scale_inv,
+                meta.qtype,
+            )
+            grads[i] = None
+            params[i].grad = None
+            fp8_grads.append(fp8_grad)
+
+        # step 5: allreduce the gradients
+        flat_fp8_grads = _flatten_dense_tensors(fp8_grads)
+        assert DistOp.is_nccl_hack()
+        dist.all_reduce(flat_fp8_grads, op=dist.ReduceOp.SUM, group=self.process_group)
+        for i, q in enumerate(_unflatten_dense_tensors(flat_fp8_grads, fp8_grads)):
+            grad = ScalingTensor(q, metas[i])
+            # average by data-parallel world size
+            grad.div_(world_size)
+            params[i].grad = grad
+
+
+class DistributedDataParallel(torch.nn.parallel.DistributedDataParallel):
+    def __init__(self, module, **kwargs):
+        super().__init__(module, **kwargs)
+        scaling_params = [p for p in self.parameters() if p.requires_grad if isinstance(p, ScalingTensor)]
+        self.scaling_tensor_reducer = ScalingTensorReducer(scaling_params, self.process_group, self.bucket_bytes_cap)
+    def forward(self, *inputs, **kwargs):
+        if torch.is_grad_enabled():
+            self.scaling_tensor_reducer.reset_buckets()
+        out = super().forward(*inputs, **kwargs)
+        return out
+
+
+torch.nn.parallel.DistributedDataParallel = DistributedDataParallel

--- a/msamp/nn/parallel/distributed.py
+++ b/msamp/nn/parallel/distributed.py
@@ -152,7 +152,7 @@ class ScalingTensorReducer:
             # step 5: allreduce the gradients
             flat_fp8_grads = self.buffer.narrow(0, bucket_start, bucket_end - bucket_start)
             torch.cuda.default_stream().wait_stream(self.reduction_stream)
-            if True:
+            if False:
                 # [TODO] support native distributed API with FP8 support
                 handle = dist.all_reduce(flat_fp8_grads, op=dist.ReduceOp.SUM, group=self.process_group, async_op=True)
                 self.dist_handles.append(handle)

--- a/msamp/nn/parallel/distributed.py
+++ b/msamp/nn/parallel/distributed.py
@@ -129,6 +129,7 @@ class ScalingTensorReducer:
                 meta.scale_inv,
                 meta.qtype,
             )
+            meta.scale_inv.data.copy_(torch.reciprocal(meta.scale))
             grads[i] = None
             params[i].grad = None
             fp8_grads.append(fp8_grad)

--- a/msamp/nn/parallel/distributed.py
+++ b/msamp/nn/parallel/distributed.py
@@ -25,7 +25,6 @@ class ScalingTensorReducer:
         self._build_buckets(parameters)
         self._register_backward_hooks()
         self.bucket_unreduced_param_ids = dict()
-        self.reduction_stream = torch.cuda.Stream()
         self.dist_handles = []
 
     def get_param_id(self, param):
@@ -41,7 +40,6 @@ class ScalingTensorReducer:
         for handle in self.dist_handles:
             handle.wait()
         self.dist_handles = []
-        torch.cuda.current_stream().wait_stream(self.reduction_stream)
 
     def _create_buffer(self, parameters):
         buffer_size = sum(p.numel() for p in parameters)
@@ -95,70 +93,69 @@ class ScalingTensorReducer:
         return hook_fn
 
     def _reduce_bucket(self, bucket_id):
-        self.reduction_stream.wait_stream(torch.cuda.current_stream())
-        with torch.cuda.stream(self.reduction_stream):
-            # step 1: collect the gradients
-            param_ids = self.bucket_to_param_ids[bucket_id]
-            params = [self.parameters[i] for i in param_ids]
-            grads = [p.grad for p in params]
-            metas = [g.meta for g in grads]
+        # step 1: collect the gradients
+        param_ids = self.bucket_to_param_ids[bucket_id]
+        params = [self.parameters[i] for i in param_ids]
+        grads = [p.grad for p in params]
+        metas = [g.meta for g in grads]
 
-            # step 2: synchronize the amax
-            # shape of amaxs: (n, )
-            amaxs = torch.stack([g.max().float() for g in grads])
-            scales = torch.stack([meta.scale for meta in metas])
-            # convert NAN to INF since NCCL-ReduceMax ignores NAN
-            # notice: nan and posinf must be INF
-            amaxs.nan_to_num_(nan=torch.inf, posinf=torch.inf)
-            dist.all_reduce(amaxs, op=dist.ReduceOp.MAX, group=self.process_group)
+        # step 2: synchronize the amax
+        # shape of amaxs: (n, )
+        amaxs = torch.stack([g.max().float() for g in grads])
+        scales = torch.stack([meta.scale for meta in metas])
+        # convert NAN to INF since NCCL-ReduceMax ignores NAN
+        # notice: nan and posinf must be INF
+        amaxs.nan_to_num_(nan=torch.inf, posinf=torch.inf)
+        dist.all_reduce(amaxs, op=dist.ReduceOp.MAX, group=self.process_group)
 
-            # step 3: update scaling factor
-            wgrad_qtype = Dtypes.kfloat8_e4m3
-            fp_max = Floating.qfp_max[wgrad_qtype]
-            world_size = dist.get_world_size(self.process_group)
-            pre_scale = 1.0 / math.sqrt(world_size)
-            # shape of sf: (n, )
-            sf = ScalingMeta.compute_scaling_factor(amaxs, scales, fp_max, margin=0)
-            sf.mul_(pre_scale)
+        # step 3: update scaling factor
+        wgrad_qtype = Dtypes.kfloat8_e4m3
+        fp_max = Floating.qfp_max[wgrad_qtype]
+        world_size = dist.get_world_size(self.process_group)
+        pre_scale = 1.0 / math.sqrt(world_size)
+        # shape of sf: (n, )
+        sf = ScalingMeta.compute_scaling_factor(amaxs, scales, fp_max, margin=0)
+        sf.mul_(pre_scale)
 
-            # update meta.amax[0] to global amax
-            for meta, amax in zip(metas, amaxs):
-                meta.amax[0] = amax
+        # update meta.amax[0] to global amax
+        for meta, amax, scale in zip(metas, amaxs, sf):
+            meta.amax[0] = amax
+            meta.scale.copy_(scale)
 
-            # step 4: quantize the gradients to FP8
-            dummy_amax = torch.empty((1, ), dtype=torch.float32, device=self.device)
-            bucket_range = self.bucket_to_range[bucket_id]
-            bucket_start, bucket_end = bucket_range
-            bucket_offset = bucket_start
-            for i, (grad, meta) in enumerate(zip(grads, metas)):
-                fp8_grad = TransformerEngineWrapper.cast_to_fp8(
-                    grad.view(1, -1),
-                    meta.scale,
-                    dummy_amax,
-                    meta.scale_inv,
-                    meta.qtype,
-                )
-                meta.scale_inv.data.copy_(torch.reciprocal(meta.scale))
-                grads[i] = None
-                # copy fp8_grad to buffer
-                grad_numel = grad.numel()
-                buf = self.buffer.narrow(0, bucket_offset, grad_numel).view_as(fp8_grad)
-                buf.copy_(fp8_grad)
-                params[i].grad = ScalingTensor(buf, meta)
-                params[i].grad.div_(world_size)
-                bucket_offset += grad_numel
+        # step 4: quantize the gradients to FP8
+        bucket_range = self.bucket_to_range[bucket_id]
+        bucket_start, bucket_end = bucket_range
+        bucket_offset = bucket_start
+        dummy_amax = torch.empty((1, ), dtype=torch.float32, device=self.device)
+        for i, (grad, meta) in enumerate(zip(grads, metas)):
+            fp8_grad = TransformerEngineWrapper.cast_to_fp8(
+                grad.view(1, -1),
+                meta.scale,
+                dummy_amax,
+                meta.scale_inv,
+                meta.qtype,
+            )
+            meta.scale_inv.data.copy_(torch.reciprocal(meta.scale))
+            grads[i] = None
+            # copy fp8_grad to buffer
+            grad_numel = grad.numel()
+            buf = self.buffer.narrow(0, bucket_offset, grad_numel).view_as(fp8_grad)
+            buf.copy_(fp8_grad)
+            params[i].grad = ScalingTensor(buf, meta)
+            params[i].grad.div_(world_size)
+            bucket_offset += grad_numel
 
-            # step 5: allreduce the gradients
-            flat_fp8_grads = self.buffer.narrow(0, bucket_start, bucket_end - bucket_start)
-            if True:
-                # [TODO] support native distributed API with FP8 support
-                handle = dist.all_reduce(flat_fp8_grads, op=dist.ReduceOp.SUM, group=self.process_group, async_op=True)
-                self.dist_handles.append(handle)
+        # step 5: allreduce the gradients
+        flat_fp8_grads = self.buffer.narrow(0, bucket_start, bucket_end - bucket_start)
+        if True:
+            # [TODO] support native distributed API with FP8 support
+            handle = dist.all_reduce(flat_fp8_grads, op=dist.ReduceOp.SUM, group=self.process_group, async_op=True)
+            self.dist_handles.append(handle)
+        else:
+            if dist.get_world_size() == dist.get_world_size(self.process_group):
+                DistOp.all_reduce(flat_fp8_grads, qtype=wgrad_qtype, op=dist.ReduceOp.SUM)
             else:
-                if dist.get_world_size() == dist.get_world_size(self.process_group):
-                    DistOp.all_reduce(flat_fp8_grads, qtype=wgrad_qtype, op=dist.ReduceOp.SUM)
-                else:
-                    raise RuntimeError("msamp.nn.parallel.DistributedDataParallel only supports `self.process_group is None`")
+                raise RuntimeError("msamp.nn.parallel.DistributedDataParallel only supports `self.process_group is None`")
 
 
 class _DDPSink(torch.autograd.Function):

--- a/msamp/nn/state.py
+++ b/msamp/nn/state.py
@@ -14,7 +14,6 @@ class ModelState:
     def __init__(self):
         """Constructor."""
         self._ready_to_scale_tensor = False
-        self._ready_to_all_reduce_grads = False
         # dict[str, dict[str, tensor]], store the flattened scaling metas in all FP8Linear modules.
         # key in input/wgrad/output, value is a dict whose key is scales/amaxs/amax_counters
         # and value is flattened tensors.
@@ -36,20 +35,6 @@ class ModelState:
             value (bool): Value to set.
         """
         self._ready_to_scale_tensor = value
-
-    @property
-    def ready_to_all_reduce_grads(self):
-        """Decoration function to access _ready_to_all_reduce_grads variable."""
-        return self._ready_to_all_reduce_grads
-
-    @ready_to_all_reduce_grads.setter
-    def ready_to_all_reduce_grads(self, value):
-        """Set the value of _ready_to_all_reduce_grads variable.
-
-        Args:
-            value (bool): Value to set.
-        """
-        self._ready_to_all_reduce_grads = value
 
     @property
     def flattened_scaling_metas(self):

--- a/msamp/optim/optimizer.py
+++ b/msamp/optim/optimizer.py
@@ -38,19 +38,9 @@ class LBOptimizer(Optimizer):
         Args:
             closure (callable, optional): A closure that reevaluates the model and returns the loss.
         """
-        assert not model_state.ready_to_all_reduce_grads, \
-            'Please call optimizer.all_reduce_grads(model) before calling optimizer.step()'
         rtn = self.lb_step(closure)
         self._update_scaling_factors()
         return rtn
-
-    def all_reduce_grads(self, model):
-        """All-reduce gradients of parameters."""
-        scaling_params = [p for p in model.parameters() if isinstance(p, ScalingParameter)]
-        grads = [p.grad for p in scaling_params if p.grad is not None]
-        TensorDist.all_reduce_avg(grads)
-        # make sure that FP8 weight gradients have been reduced.
-        model_state.ready_to_all_reduce_grads = False
 
     def lb_step(self, closure=None):
         """Performs a single optimization step. The subclass needs to implement this method.


### PR DESCRIPTION
**Description**
In this PR, the native pytorch `DistributedDataParallel` is overrided by `msmap.nn.parallel.distributed.DistributedDataParallel`, which supports ScalingTensor as the parameters. The weight gradients will be put in a bucket then all-reduced. The function `optimizer.all_reduce_grads` is deprecated.

**Major Revision**
- Add `msmap.nn.parallel.distributed.DistributedDataParallel`

**TODO**
- [x] asynchronous all reduce
- [ ] refactor code
- [ ] check training with deepspeed
- [ ] unit test for `msmap.nn.parallel.distributed.DistributedDataParallel`
- [ ] update ms-amp examples
     remove `optimizer.all_reduce_grads()`
