### PR TITLE
fix(zero): fix the bug of gradient accumulation in FP8 deepspeed ZeRO

### DIFF
--- a/msamp/common/tensor/tensor.py
+++ b/msamp/common/tensor/tensor.py
@@ -456,7 +456,7 @@ class ScalingTensor:
         # ref
         with torch.no_grad():
             if isinstance(data, ScalingTensor):
-                if self.meta.locked:
+                if self.meta.locked and self.meta is not data.meta:
                     raise ValueError('This ScalingTensor is locked.')
                 self.value.data = data.value
                 self.meta = data.meta

--- a/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
+++ b/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
@@ -325,8 +325,9 @@ class FP8DeepSpeedZeroOptimizer(DeepSpeedZeroOptimizer):
                 else:
                     avg_new = self.fp8_get_flat_partition(self.fp8_params_in_partition[i])
                     for accumulated_grad, new_avg_grad in zip(self.fp8_averaged_gradients[i], avg_new):
-                        accumulated_grad.data = (accumulated_grad.float() +
-                                                 new_avg_grad.float()).cast(WEIGHT_GRAD_QTYPE, in_time=True)
+                        accumulated_grad.data.copy_(
+                            (accumulated_grad.float() + new_avg_grad.float()).cast(WEIGHT_GRAD_QTYPE)
+                        )
 
         self._release_ipg_buffers()
 

--- a/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
+++ b/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
@@ -325,8 +325,9 @@ class FP8DeepSpeedZeroOptimizer(DeepSpeedZeroOptimizer):
                 else:
                     avg_new = self.fp8_get_flat_partition(self.fp8_params_in_partition[i])
                     for accumulated_grad, new_avg_grad in zip(self.fp8_averaged_gradients[i], avg_new):
-                        accumulated_grad.data.copy_(
-                            (accumulated_grad.float() + new_avg_grad.float()).cast(WEIGHT_GRAD_QTYPE)
+                        accumulated_grad.data = (
+                            (accumulated_grad.float() +
+                             new_avg_grad.float()).cast(WEIGHT_GRAD_QTYPE, meta=accumulated_grad.data.meta)
                         )
 
         self._release_ipg_buffers()

--- a/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
+++ b/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
@@ -327,7 +327,7 @@ class FP8DeepSpeedZeroOptimizer(DeepSpeedZeroOptimizer):
                     for accumulated_grad, new_avg_grad in zip(self.fp8_averaged_gradients[i], avg_new):
                         accumulated_grad.data = (
                             (accumulated_grad.float() +
-                             new_avg_grad.float()).cast(WEIGHT_GRAD_QTYPE, meta=accumulated_grad.data.meta)
+                             new_avg_grad.float()).cast(WEIGHT_GRAD_QTYPE, meta=accumulated_grad.meta)
                         )
 
         self._release_ipg_buffers()

--- a/tests/deepspeed/test_zero.py
+++ b/tests/deepspeed/test_zero.py
@@ -74,3 +74,15 @@ class FP8DeepSpeedZeroOptimizerTestCase(unittest.TestCase):
             }
         }
         self._check_zero(config)
+
+    @decorator.cuda_test
+    def test_stage2_with_grad_accumulation(self):
+        """Test fp8 deepspeed zero-stage2 with gradient accumulation."""
+        config = {
+            'train_batch_size': 2,
+            'train_micro_batch_size_per_gpu': 1,
+            'zero_optimization': {
+                'stage': 2,
+            }
+        }
+        self._check_zero(config)

--- a/tests/deepspeed/test_zero.py
+++ b/tests/deepspeed/test_zero.py
@@ -96,6 +96,16 @@ class FP8DeepSpeedZeroOptimizerTestCase(unittest.TestCase):
         config = {
             'train_batch_size': 2,
             'train_micro_batch_size_per_gpu': 1,
+            'optimizer': {
+                'type': 'adamw',
+                'params': {
+                    'torch_adam': True,
+                }
+            },
+            'msamp': {
+                'enabled': True,
+                'opt_level': 'O3',
+            },
             'zero_optimization': {
                 'stage': 2,
             }


### PR DESCRIPTION
**Description**
When weight gradients are accumulated, the statement `accumulated_grad.data = (accumulated_grad.float() +
 new_avg_grad.float()).cast(WEIGHT_GRAD_QTYPE, in_time=True)` is called. However, the argument `in_time` does not exist in MS-AMP, and an error will be raised. This PR fixes the bug.

**Major Revision**
- fix gradient accumulation in FP8 DeepSpeed ZeRO
- unit test