### PR TITLE
Support tensor parallelism

### DIFF
--- a/msamp/common/tensor/cast.py
+++ b/msamp/common/tensor/cast.py
@@ -40,7 +40,7 @@ class TypeCast:
             meta.amax[0].nan_to_num_(nan=torch.inf, posinf=torch.inf)
             world_size = DistUtil.get_world_size()
             if world_size > 1:
-                dist.all_reduce(meta.amax[0], op=dist.ReduceOp.MAX)
+                dist.all_reduce(meta.amax[0], op=dist.ReduceOp.MAX, group=meta.group)
                 sync_amax = meta.amax[0].clone()
         if in_time or sync:
             meta.reset_scaling_factor()
@@ -84,7 +84,7 @@ class TypeCast:
             meta.amax[0].nan_to_num_(nan=torch.inf, posinf=torch.inf)
             world_size = DistUtil.get_world_size()
             if world_size > 1:
-                dist.all_reduce(meta.amax[0], op=dist.ReduceOp.MAX)
+                dist.all_reduce(meta.amax[0], op=dist.ReduceOp.MAX, group=meta.group)
         if in_time or sync:
             # notice: we scale the tensor with qtype FP8-E4M3.
             meta.reset_scaling_factor(qtype=Dtypes.kfloat8_e4m3)

--- a/msamp/common/tensor/meta.py
+++ b/msamp/common/tensor/meta.py
@@ -96,7 +96,6 @@ class ScalingMeta:
         self.amax.copy_(src.amax)
         self.amax_counter.copy_(src.amax_counter)
         self.window_size = src.window_size
-        self.group = src.group
 
     def clone(self):
         """Returns a copy of this object."""

--- a/msamp/common/tensor/tensor_dist.py
+++ b/msamp/common/tensor/tensor_dist.py
@@ -63,20 +63,21 @@ class TensorDist:
         cls._dist_tensors_after_flatten(buffer, dist_fn)
 
     @classmethod
-    def broadcast(cls, tensors, src, bucket_size=BROADCAST_BUCKET_SIZE):
+    def broadcast(cls, tensors, src, bucket_size=BROADCAST_BUCKET_SIZE, group=None):
         """Broadcast tensors across processes in one process group.
 
         Args:
             tensors (list of torch.Tensor or ScalingTensor): Tensors to be broadcasted.
             src (int): Source rank.
             bucket_size (int): Bucket size in bytes.
+            group (ProcessGroup): Process group.
         """
         world_size = DistUtil.get_world_size()
         if world_size == 1:
             return
 
         def dist_fn(x):
-            return dist.broadcast(x, src=src)
+            return dist.broadcast(x, src=src, group=group)
 
         if isinstance(tensors[0], ScalingTensor):
             values = [p.value for p in tensors]

--- a/msamp/nn/linear.py
+++ b/msamp/nn/linear.py
@@ -178,7 +178,7 @@ class LinearReplacer:
 
         fp8_names = [k for k, _ in fp8_named_weights]
         fp8_weights = [p for _, p in fp8_named_weights]
-        TensorDist.broadcast(fp8_weights, src=0, group=group)
+        TensorDist.broadcast(fp8_weights, src=src_rank, group=group)
 
         for k, p in fp8_named_weights:
             p._param_name = k

--- a/msamp/nn/linear.py
+++ b/msamp/nn/linear.py
@@ -159,7 +159,7 @@ class LinearReplacer:
         return model
 
     @classmethod
-    def replace(cls, model, weight_qtype=Dtypes.kfloat16):
+    def replace(cls, model, weight_qtype=Dtypes.kfloat16, src_rank=0, group=None):
         """Replace torch.nn.Linear with FP8Linear in a model.
 
         Besides replace linear modules, it also broadcasts weights and register scaling data to model state.
@@ -167,6 +167,8 @@ class LinearReplacer:
         Args:
             model (torch.nn.Module): Model to replace.
             weight_qtype (Dtypes.QType, optional): Qtype of weight. Defaults to kfloat16.
+            src_rank (int, optional): Source rank of broadcast. Defaults to 0.
+            group (torch.distributed.ProcessGroup, optional): Group of broadcast. Defaults to None.
 
         Return:
             model (torch.nn.Module): Model in which all Linear modules are replaced with FP8Linear.
@@ -176,7 +178,7 @@ class LinearReplacer:
 
         fp8_names = [k for k, _ in fp8_named_weights]
         fp8_weights = [p for _, p in fp8_named_weights]
-        TensorDist.broadcast(fp8_weights, src=0)
+        TensorDist.broadcast(fp8_weights, src=0, group=group)
 
         for k, p in fp8_named_weights:
             p._param_name = k
@@ -185,5 +187,5 @@ class LinearReplacer:
         # to sync them.
         torch.nn.parallel.DistributedDataParallel._set_params_and_buffers_to_ignore_for_model(model, fp8_names)
 
-        model_state.register_scaling_metas(model)
+        model_state.register_scaling_metas(model, group)
         return model

--- a/msamp/nn/state.py
+++ b/msamp/nn/state.py
@@ -151,11 +151,12 @@ class ModelState:
             ModelState._check_in_mem(v.amax, metas['amaxs'])
             ModelState._check_in_mem(v.amax_counter, metas['amax_counters'])
 
-    def register_scaling_metas(self, model):
+    def register_scaling_metas(self, model, group=None):    # noqa: C901
         """Register scaling metas of the model to model state.
 
         Args:
             model (torch.nn.Module): model to register.
+            group (torch.distributed.ProcessGroup): process group to register.
         """
         for k, m in model.named_modules():
             if hasattr(m, 'scaling_metas'):
@@ -181,7 +182,10 @@ class ModelState:
             values[key] = ModelState._flatten_scaling_metas([m[key] for m in metas])
 
         self._flattened_scaling_metas = values
-
+        # Set group for ScalingMeta.
+        for meta in metas:
+            for m in meta.values():
+                m.group = group
         # check metas memory
         for meta in metas:
             self.check_metas_in_flat(meta)


### PR DESCRIPTION
**Description**
To support tensor parallelism, need to support broadcast and reduce tensor in a group.
The default value of group is None. We don't have UT for distributed process group, may add UT later.

**Major Revision**
- Broadcast tensors in a process group when replacing Linear with FP8Linear.
- All reduce amax in a process group when cast tensor to fp8/fp16