### PR TITLE
Support bf16+pipeline+ZeRO1

### DIFF
--- a/msamp/deepspeed/__init__.py
+++ b/msamp/deepspeed/__init__.py
@@ -10,10 +10,11 @@ from torch.optim import Optimizer
 from deepspeed import *    # noqa
 from deepspeed import __version__, __git_hash__, __git_branch__, log_dist, logger,  get_accelerator, \
                       DeepSpeedOptimizerCallable, DeepSpeedSchedulerCallable, DeepSpeedConfig, \
-                      DeepSpeedHybridEngine, _LRScheduler, zero, PipelineModule, PipelineEngine
+                      DeepSpeedHybridEngine, _LRScheduler, zero, PipelineModule
 
 from msamp.deepspeed.runtime.config import MSAMPDeepSpeedConfig
 from msamp.deepspeed.runtime.engine import MSAMPDeepSpeedEngine
+from msamp.deepspeed.runtime.pipe.engine import MSAMPPipelineEngine
 
 
 def initialize(
@@ -148,7 +149,7 @@ def initialize(
         assert mpu is None, 'mpu must be None with pipeline parallelism'
         mpu = model.mpu()
         config_class = DeepSpeedConfig(config, mpu)
-        engine = PipelineEngine(
+        engine = MSAMPPipelineEngine(
             args=args,
             model=model,
             optimizer=optimizer,

--- a/msamp/deepspeed/__init__.py
+++ b/msamp/deepspeed/__init__.py
@@ -9,7 +9,7 @@ import torch
 from torch.optim import Optimizer
 from deepspeed import *    # noqa
 from deepspeed import __version__, __git_hash__, __git_branch__, log_dist, logger,  get_accelerator, \
-                      DeepSpeedOptimizerCallable, DeepSpeedSchedulerCallable, DeepSpeedConfig, \
+                      DeepSpeedOptimizerCallable, DeepSpeedSchedulerCallable, \
                       DeepSpeedHybridEngine, _LRScheduler, zero, PipelineModule
 
 from msamp.deepspeed.runtime.config import MSAMPDeepSpeedConfig

--- a/msamp/deepspeed/__init__.py
+++ b/msamp/deepspeed/__init__.py
@@ -148,7 +148,7 @@ def initialize(
     else:
         assert mpu is None, 'mpu must be None with pipeline parallelism'
         mpu = model.mpu()
-        config_class = DeepSpeedConfig(config, mpu)
+        config_class = MSAMPDeepSpeedConfig(config, mpu)
         engine = MSAMPPipelineEngine(
             args=args,
             model=model,

--- a/msamp/deepspeed/runtime/engine.py
+++ b/msamp/deepspeed/runtime/engine.py
@@ -242,6 +242,10 @@ class MSAMPDeepSpeedEngine(DeepSpeedEngine):
                 communication_data_type=self.communication_data_type,
                 elastic_checkpoint=self.zero_elastic_checkpoint()
             )
+            # update_hp_grads and clear_lp_grads will be called in PipelineEngine when using pipeline+bf16+zero1,
+            # so we just set them to None.
+            zero_t.update_hp_grads = lambda instance, clear_lp_grads: None
+            zero_t.clear_lp_grads = lambda instance: None
 
         elif zero_stage == ZeroStageEnum.weights:
             assert not self.has_moe_layers, 'MoE not supported with Stage 3'

--- a/msamp/deepspeed/runtime/pipe/engine.py
+++ b/msamp/deepspeed/runtime/pipe/engine.py
@@ -24,7 +24,7 @@ class MSAMPPipelineEngine(MSAMPDeepSpeedEngine, PipelineEngine):
                 elif self.zero_optimization_stage() == ZeroStageEnum().gradients:
                     self.allreduce_gradients(bucket_size=MEMORY_OPT_ALLREDUCE_SIZE)
                 else:
-                    raise NotImplementedError("PP+BF16 only work for ZeRO Stage 2")
+                    raise NotImplementedError('PP+BF16 only work for ZeRO Stage 2')
             else:
                 self.allreduce_gradients(bucket_size=MEMORY_OPT_ALLREDUCE_SIZE)
         self._force_grad_boundary = False

--- a/msamp/deepspeed/runtime/pipe/engine.py
+++ b/msamp/deepspeed/runtime/pipe/engine.py
@@ -24,7 +24,7 @@ class MSAMPPipelineEngine(MSAMPDeepSpeedEngine, PipelineEngine):
                 elif self.zero_optimization_stage() == ZeroStageEnum().gradients:
                     self.allreduce_gradients(bucket_size=MEMORY_OPT_ALLREDUCE_SIZE)
                 else:
-                    raise NotImplementedError('PP+BF16 only work for ZeRO Stage 2')
+                    raise NotImplementedError('PP+BF16 only work for ZeRO Stage 1 and 2')
             else:
                 self.allreduce_gradients(bucket_size=MEMORY_OPT_ALLREDUCE_SIZE)
         self._force_grad_boundary = False

--- a/msamp/deepspeed/runtime/pipe/engine.py
+++ b/msamp/deepspeed/runtime/pipe/engine.py
@@ -1,0 +1,35 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""MS-AMP PipelineEngine."""
+
+from deepspeed.utils import instrument_w_nvtx
+from deepspeed.runtime.pipe.engine import PipelineEngine, schedule
+from deepspeed.runtime.engine import MEMORY_OPT_ALLREDUCE_SIZE
+
+from msamp.nn import model_state
+from msamp.deepspeed.runtime.engine import MSAMPDeepSpeedEngine
+
+
+class MSAMPPipelineEngine(MSAMPDeepSpeedEngine, PipelineEngine):
+    """Pipeline engine supports pipeline+ZeRO+BF16."""
+    def _exec_reduce_grads(self):
+        """Reduce gradients across pipeline stages."""
+        self._force_grad_boundary = True
+        if self.pipeline_enable_backward_allreduce:
+            if self.bfloat1_enabled():
+                if self.zero_optimization_stage() == 0:
+                    self._bf16_reduce_grads()
+                else:
+                    self.allreduce_gradients(bucket_size=MEMORY_OPT_ALLREDUCE_SIZE)
+            else:
+                self.allreduce_gradients(bucket_size=MEMORY_OPT_ALLREDUCE_SIZE)
+        self._force_grad_boundary = False
+
+    @instrument_w_nvtx
+    def allreduce_gradients(self, bucket_size=MEMORY_OPT_ALLREDUCE_SIZE):
+        """Allreduce gradients across pipeline stages."""
+        model_state.ready_to_all_reduce_grads = False
+        super().allreduce_gradients(bucket_size=bucket_size)
+
+    PipelineEngine._INSTRUCTION_MAP.update({schedule.ReduceGrads: _exec_reduce_grads})

--- a/tests/deepspeed/test_initialize.py
+++ b/tests/deepspeed/test_initialize.py
@@ -7,12 +7,12 @@ import unittest
 
 import torch
 import torch.nn as nn
-from deepspeed.runtime.pipe.engine import PipelineEngine
 from deepspeed.runtime.hybrid_engine import DeepSpeedHybridEngine
 from deepspeed.pipe import PipelineModule
 
 from msamp import deepspeed
 from msamp.deepspeed.runtime.engine import MSAMPDeepSpeedEngine
+from msamp.deepspeed.runtime.pipe.engine import MSAMPPipelineEngine
 from tests.helper import decorator
 
 
@@ -40,7 +40,7 @@ class DeepSpeedInitializeTestCase(unittest.TestCase):
 
         model2 = PipelineModule(layers=model2, num_stages=1)
         model2, _, _, _ = deepspeed.initialize(model=model2, config=config)
-        assert isinstance(model2, PipelineEngine)
+        assert isinstance(model2, MSAMPPipelineEngine)
 
         config = {'train_batch_size': 1, 'hybrid_engine': {'enabled': True}}
         model3 = torch.nn.Linear(4, 4)

--- a/tests/deepspeed/test_optimizer.py
+++ b/tests/deepspeed/test_optimizer.py
@@ -34,8 +34,6 @@ class FP8OptimizerTestCase(unittest.TestCase):
         model = torch.nn.Linear(4, 4, bias=False).cuda()
         model1 = LinearReplacer.replace(model, Dtypes.kfloat16)
         model2 = LinearReplacer.replace(model, Dtypes.kfloat16)
-        print(f'model1.weight:{model1.weight.float()}')
-        print(f'model2.weight: {model2.weight.float()}')
         assert torch.equal(model1.weight.float(), model2.weight.float())
         opt1 = LBAdamW(list(model1.parameters()))
         opt2 = LBAdamW(list(model2.parameters()))


### PR DESCRIPTION
**Description**
Support pipeline+zero+bf16.

The original PipelineEngine does not support bf16+ZeRO-1. Only support fp16+ZeRo-1. This PR targes for supporting bf16+ZeRO-1.

We can use the official [pipeline parallelism example](https://github.com/microsoft/DeepSpeedExamples/blob/master/training/pipeline_parallelism/run.sh) to test.

1 Modify [train.py](https://github.com/microsoft/DeepSpeedExamples/blob/master/training/pipeline_parallelism/train.py) 
  (1) Add transforms.ConvertImageDtype(dtype= torch.bfloat16) in transform
![image](https://github.com/Azure/MS-AMP/assets/4133758/b7b7f8c3-76e9-4486-932e-d32ef779777e)
  (2) add `from msamp import msamp_deepspeed` and change deepspeed.initialize to msamp_deepspeed.initialize

2 Add "bf16" and "zero_optimization" section in ds_config.json

 "bf16": { 
    "enabled": true 
  },
  "zero_optimization": {
    "stage": 1,
    "allgather_partitions": true,
    "reduce_scatter": true,
    "allgather_bucket_size": 50000000,
    "reduce_bucket_size": 50000000,
    "overlap_comm": true,
    "contiguous_gradients": true,
    "cpu_offload": false
  },
3 Run this example:
```
deepspeed  --num_gpus 4 train.py --deepspeed_config=ds_config.json -p 2 --steps=200
```
If we can train this model successfully, that means we can support pipeline+bf16+zero-1. 