### PR TITLE
Remove env PYTHONOPTIMIZE in docker image

### DIFF
--- a/dockerfile/torch1.14-cuda11.8.dockerfile
+++ b/dockerfile/torch1.14-cuda11.8.dockerfile
@@ -36,8 +36,7 @@ RUN apt-get update && \
 
 ARG NUM_MAKE_JOBS=
 ENV PATH="${PATH}" \
-    LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}" \
-    PYTHONOPTIMIZE=1
+    LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
 
 WORKDIR /opt/msamp
 

--- a/dockerfile/torch2.1-cuda12.1.dockerfile
+++ b/dockerfile/torch2.1-cuda12.1.dockerfile
@@ -36,8 +36,7 @@ RUN apt-get update && \
 
 ARG NUM_MAKE_JOBS=
 ENV PATH="${PATH}" \
-    LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}" \
-    PYTHONOPTIMIZE=1
+    LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
 
 WORKDIR /opt/msamp
 


### PR DESCRIPTION
**Description**
Remove env `PYTHONOPTIMIZE=1` in docker image since it will skip `assert 0` in python.

When env `PYTHONOPTIMIZE=1`,
```python
Python 3.8.10 (default, Nov 14 2022, 12:59:47)
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> assert 0
```
No exception raises.