### PR TITLE
Fix bug: undeclared symbols when executing `make postinstall`  

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ apt-get update
 apt install build-essential devscripts debhelper fakeroot
 make pkg.debian.build
 dpkg -i build/pkg/deb/libnccl2_*.deb
+dpkg -i build/pkg/deb/libnccl-dev_2*.deb
 
 cd -
 ```


### PR DESCRIPTION
**Description**
Update document to fix the nccl installation issue.
Fix #88 

**Major Revision**
- Install libnccl-dev package