### PR TITLE
Add fp8 ddp and remove ready_to_all_reduce

### DIFF
--- a/examples/mnist_ddp.py
+++ b/examples/mnist_ddp.py
@@ -191,6 +191,7 @@ def main():
     if args.enable_msamp:
         print(f'msamp is enabled, opt_level: {args.opt_level}')
         model, optimizer = msamp.initialize(model, optimizer, opt_level=args.opt_level)
+        msamp.nn.model_state.use_torch_ddp = True
 
     model = torch.nn.parallel.DistributedDataParallel(
         model, device_ids=[args.local_rank], output_device=args.local_rank

--- a/examples/mnist_ddp.py
+++ b/examples/mnist_ddp.py
@@ -191,7 +191,6 @@ def main():
     if args.enable_msamp:
         print(f'msamp is enabled, opt_level: {args.opt_level}')
         model, optimizer = msamp.initialize(model, optimizer, opt_level=args.opt_level)
-        msamp.nn.model_state.use_fp8_ddp = True
 
     model = torch.nn.parallel.DistributedDataParallel(
         model, device_ids=[args.local_rank], output_device=args.local_rank

--- a/examples/mnist_ddp.py
+++ b/examples/mnist_ddp.py
@@ -191,7 +191,7 @@ def main():
     if args.enable_msamp:
         print(f'msamp is enabled, opt_level: {args.opt_level}')
         model, optimizer = msamp.initialize(model, optimizer, opt_level=args.opt_level)
-        msamp.nn.model_state.use_torch_ddp = True
+        msamp.nn.model_state.use_fp8_ddp = True
 
     model = torch.nn.parallel.DistributedDataParallel(
         model, device_ids=[args.local_rank], output_device=args.local_rank

--- a/msamp/deepspeed/runtime/engine.py
+++ b/msamp/deepspeed/runtime/engine.py
@@ -12,7 +12,6 @@ from deepspeed.runtime.engine import SparseTensor, ZERO_OPTIMIZATION, AMP, amp, 
 
 from msamp import initialize as msamp_initialize
 from msamp.common.tensor import ScalingTensor, TensorDist
-from msamp.nn import model_state
 from msamp.optim import LBOptimizer
 from msamp.deepspeed.runtime.fp8.fused_optimizer import FP8Optimizer
 from msamp.deepspeed.runtime.zero import utils    # noqa: F401

--- a/msamp/deepspeed/runtime/engine.py
+++ b/msamp/deepspeed/runtime/engine.py
@@ -385,9 +385,6 @@ class MSAMPDeepSpeedEngine(DeepSpeedEngine):
 
         if allreduce_gradients and self.enable_backward_allreduce:
             # Traditional code path that allreduces the module parameter grads
-            # It will not call optimizer.all_reduce_grads so we set ready_to_all_reduce_grads to False.
-            # In optimizer.step, ready_to_all_reduce_grads is supposed to be False.
-            model_state.ready_to_all_reduce_grads = False
             self.allreduce_gradients()
 
         self._stop_timers(self.engine_timers.backward_reduce_timers)

--- a/msamp/deepspeed/runtime/pipe/engine.py
+++ b/msamp/deepspeed/runtime/pipe/engine.py
@@ -8,7 +8,6 @@ from deepspeed.runtime.pipe.engine import PipelineEngine, schedule
 from deepspeed.runtime.engine import MEMORY_OPT_ALLREDUCE_SIZE
 from deepspeed.runtime.zero.config import ZeroStageEnum
 
-from msamp.nn import model_state
 from msamp.deepspeed.runtime.engine import MSAMPDeepSpeedEngine
 
 

--- a/msamp/deepspeed/runtime/pipe/engine.py
+++ b/msamp/deepspeed/runtime/pipe/engine.py
@@ -32,7 +32,6 @@ class MSAMPPipelineEngine(MSAMPDeepSpeedEngine, PipelineEngine):
     @instrument_w_nvtx
     def allreduce_gradients(self, bucket_size=MEMORY_OPT_ALLREDUCE_SIZE):
         """Allreduce gradients across pipeline stages."""
-        model_state.ready_to_all_reduce_grads = False
         # Pass (PP) gas boundary flag to optimizer (required for zero)
         self.optimizer.is_gradient_accumulation_boundary = self.is_gradient_accumulation_boundary()
         # ZeRO stage >= 2 communicates during non gradient accumulation boundaries as well

--- a/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
+++ b/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
@@ -13,7 +13,6 @@ from deepspeed.runtime.zero.stage_1_and_2 import all_gather_dp_groups, DeepSpeed
     get_accelerator, move_to_cpu, logger, see_memory_usage
 from msamp.common.tensor import ScalingTensor, ScalingMeta
 from msamp.common.dtype import Dtypes
-from msamp.nn import model_state
 from msamp.common.utils import TransformerEngineWrapper
 
 SINGLE_PARTITION_OF_FP8_GROUPS = 'single_partition_of_fp8_groups'

--- a/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
+++ b/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
@@ -279,7 +279,6 @@ class FP8DeepSpeedZeroOptimizer(DeepSpeedZeroOptimizer):
         self.reduce_ipg_grads()
         self.report_ipg_memory_usage('In ipg_epilogue after reduce_ipg_grads', 0)
         self.fp8_reduce_ipg_grads()
-        model_state.ready_to_all_reduce_grads = False
 
         # if dist.get_rank() == 0:
         #    logger.info("Params already reduced %s", self.params_already_reduced)

--- a/msamp/nn/__init__.py
+++ b/msamp/nn/__init__.py
@@ -3,13 +3,12 @@
 
 """Expose the interface of MS-AMP nn package."""
 
+from msamp.nn import functional, distributed
 from msamp.nn.parameter import ScalingParameter
 from msamp.nn.module import ScalingModule
 from msamp.nn.state import model_state
 from msamp.nn.linear import FP8Linear, LinearReplacer
-from msamp.nn import functional
 from msamp.nn.clip_grad import clip_grad_norm_
-from msamp.nn import distributed
 del functional
 del distributed
 

--- a/msamp/nn/__init__.py
+++ b/msamp/nn/__init__.py
@@ -9,6 +9,8 @@ from msamp.nn.state import model_state
 from msamp.nn.linear import FP8Linear, LinearReplacer
 from msamp.nn import functional
 from msamp.nn.clip_grad import clip_grad_norm_
+from msamp.nn import distributed
 del functional
+del distributed
 
 __all__ = ['ScalingParameter', 'ScalingModule', 'model_state', 'FP8Linear', 'LinearReplacer', 'clip_grad_norm_']

--- a/msamp/nn/distributed.py
+++ b/msamp/nn/distributed.py
@@ -236,14 +236,12 @@ class FP8DistributedDataParallel(torch.nn.parallel.DistributedDataParallel):
             kwargs (dict): The rest arguments for DistributedDataParallel.
         """
         super().__init__(module, **kwargs)
-        if model_state.use_fp8_ddp:
-            scaling_params = [p for p in self.parameters() if p.requires_grad and isinstance(p, ScalingTensor)]
-            self.scaling_tensor_reducer = _ScalingTensorReducer(
-                scaling_params, self.process_group, self.bucket_bytes_cap
-            )
+        model_state.use_fp8_ddp = True
+        scaling_params = [p for p in self.parameters() if p.requires_grad and isinstance(p, ScalingTensor)]
+        self.scaling_tensor_reducer = _ScalingTensorReducer(scaling_params, self.process_group, self.bucket_bytes_cap)
 
     def forward(self, *inputs, **kwargs):
-        """Apply _DDPSlin in forward function.
+        """Apply _DDPSink in forward function.
 
         Args:
             inputs (tuple): The input tensors.

--- a/msamp/nn/distributed.py
+++ b/msamp/nn/distributed.py
@@ -1,0 +1,193 @@
+import math
+
+import torch
+import torch.distributed as dist
+
+from msamp.common.tensor import ScalingTensor, ScalingMeta
+from msamp.common.dtype import Dtypes, Floating
+from msamp.common.utils import TransformerEngineWrapper
+from msamp.nn import model_state
+from msamp.operators.fp8_op import FP8Op
+
+
+class ScalingTensorReducer:
+    def __init__(self, parameters, process_group, bucket_bytes_cap):
+        parameters = list(parameters)
+        if not all(isinstance(p, ScalingTensor) for p in parameters):
+            raise ValueError("All parameters must be ScalingTensor")
+        # check the devices of parameters are the same
+        if not all(p.device == parameters[0].device for p in parameters):
+            raise ValueError("All parameters must be on the same device")
+        self.device = parameters[0].device
+        self.parameters = parameters
+        self.param_to_id = {p: i for i, p in enumerate(parameters)}
+        self.buffer = None
+        self.bucket_bytes_cap = bucket_bytes_cap
+        self.process_group = process_group
+        self.reduction_stream = torch.cuda.Stream(device=self.device)
+        self._build_buckets(parameters)
+        self._register_backward_hooks()
+        self.bucket_unreduced_param_ids = dict()
+        self.dist_handles = []
+
+    def get_param_id(self, param):
+        return self.param_to_id[param]
+    
+    def reset_buckets(self):
+        if len(self.bucket_unreduced_param_ids) > 0:
+            raise RuntimeError("some gradients are not reduced: {}".format(list(self.bucket_unreduced_param_ids.keys())))
+        self.bucket_unreduced_param_ids = {k: set(v) for k, v in self.bucket_to_param_ids.items()}
+    
+    def wait(self):
+        for handle in self.dist_handles:
+            handle.wait()
+        self.dist_handles.clear()
+
+    def _create_buffer(self):
+        buffer_size = sum(p.numel() for p in self.parameters)
+        return torch.empty((buffer_size, ), dtype=torch.uint8, device=self.device)
+
+    def _build_buckets(self, parameters):
+        bucket_bytes = 0
+        total_bytes = 0
+        bucket_id = 0
+        bucket_offset = 0
+        param_id_to_bucket_id = {}
+        bucket_to_param_ids = {}
+        bucket_to_range = {}
+        for p in parameters[::-1]:
+            param_id = self.get_param_id(p)
+            nbytes = p.numel()
+            param_id_to_bucket_id[param_id] = bucket_id
+            bucket_to_param_ids.setdefault(bucket_id, []).append(param_id)
+            bucket_bytes += nbytes
+            total_bytes += nbytes
+            if bucket_bytes >= self.bucket_bytes_cap:
+                bucket_to_range[bucket_id] = (bucket_offset, bucket_offset + bucket_bytes)
+                bucket_id += 1
+                bucket_bytes = 0
+
+        # the last bucket, if not empty
+        if bucket_bytes > 0:
+            bucket_to_range[bucket_id] = (bucket_offset, bucket_offset + bucket_bytes)
+        self.param_id_to_bucket_id = param_id_to_bucket_id
+        self.bucket_to_param_ids = bucket_to_param_ids
+        self.bucket_to_range = bucket_to_range
+
+    def _register_backward_hooks(self):
+        for p in self.parameters:
+            p.register_backward_post_hook(self._get_backward_hook(p))
+
+    def _get_backward_hook(self, param):
+        param_id = self.get_param_id(param)
+        bucket_id = self.param_id_to_bucket_id[param_id]
+        def hook_fn(*args, **kwargs):
+            unreduced_param_ids = self.bucket_unreduced_param_ids[bucket_id]
+            try:
+                unreduced_param_ids.remove(param_id)
+            except KeyError:
+                raise RuntimeError("gradient is already reduced")
+            if len(unreduced_param_ids) == 0:
+                # the bucket is full, reduce it
+                self._reduce_bucket(bucket_id)
+                self.bucket_unreduced_param_ids.pop(bucket_id)
+        return hook_fn
+
+    def _reduce_bucket(self, bucket_id):
+        self.reduction_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(self.reduction_stream):
+            # step 1: collect the gradients
+            param_ids = self.bucket_to_param_ids[bucket_id]
+            params = [self.parameters[i] for i in param_ids]
+            grads = [p.grad for p in params]
+            metas = [g.meta for g in grads]
+
+            # step 2: synchronize the amax
+            # shape of amaxs: (n, )
+            amaxs = torch.stack([g.abs().max().float() for g in grads])
+            scales = torch.stack([meta.scale for meta in metas])
+            # convert NAN to INF since NCCL-ReduceMax ignores NAN
+            # notice: nan and posinf must be INF
+            amaxs.nan_to_num_(nan=torch.inf, posinf=torch.inf)
+
+            # all_reduce is launched in the custom stream pool, rather than reduction_stream
+            # all_reduce will synchronize default stream when it is launched
+            dist.all_reduce(amaxs, op=dist.ReduceOp.MAX, group=self.process_group)
+            # step 3: update scaling factor
+            wgrad_qtype = Dtypes.kfloat8_e4m3
+            fp_max = Floating.qfp_max[wgrad_qtype]
+            world_size = dist.get_world_size(self.process_group)
+            pre_scale = 1.0 / math.sqrt(world_size)
+            # shape of sf: (n, )
+            sf = ScalingMeta.compute_scaling_factor(amaxs, scales, fp_max, margin=0)
+            sf.mul_(pre_scale)
+
+            # update meta.amax[0] to global amax
+            for meta, amax, scale in zip(metas, amaxs, sf):
+                meta.amax[0] = amax
+                meta.scale.copy_(scale)
+
+            # step 4: quantize the gradients to FP8
+            bucket_range = self.bucket_to_range[bucket_id]
+            bucket_start, bucket_end = bucket_range
+            bucket_offset = bucket_start
+            dummy_amax = torch.empty((1, ), dtype=torch.float32, device=self.device)
+            if self.buffer is None:
+                self.buffer = self._create_buffer()
+            print("i am in test")
+            for i, (grad, meta) in enumerate(zip(grads, metas)):
+                fp8_grad = TransformerEngineWrapper.cast_to_fp8(
+                    grad.view(1, -1),
+                    meta.scale,
+                    dummy_amax,
+                    meta.scale_inv,
+                    meta.qtype,
+                ).view_as(grad)
+                meta.scale_inv.data.copy_(torch.reciprocal(meta.scale))
+                grads[i] = None
+                # copy fp8_grad to buffer
+                grad_numel = grad.numel()
+                buf = self.buffer.narrow(0, bucket_offset, grad_numel).view_as(grad)
+                buf.copy_(fp8_grad)
+                params[i].grad = ScalingTensor(buf, meta)
+                params[i].grad.div_(world_size)
+                bucket_offset += grad_numel
+
+            # step 5: allreduce the gradients
+            flat_fp8_grads = self.buffer.narrow(0, bucket_start, bucket_end - bucket_start)
+        
+        torch.cuda.default_stream().wait_stream(self.reduction_stream)
+        FP8Op.enable_fp8(wgrad_qtype)
+        dist_handle = dist.all_reduce(flat_fp8_grads, dist.ReduceOp.SUM, self.process_group, async_op=True)
+        self.dist_handles.append(dist_handle)
+        FP8Op.disable_fp8()
+
+
+class _DDPSink(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, reducer, empty, *inputs):
+        ctx.set_materialize_grads(False)
+        ctx.reducer = reducer
+        reducer.reset_buckets()
+        return inputs
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        ctx.reducer.wait()
+        return (None, None, *grad_outputs)
+
+
+class FP8DistributedDataParallel(torch.nn.parallel.DistributedDataParallel):
+    def __init__(self, module, **kwargs):
+        super().__init__(module, **kwargs)
+        if model_state.use_torch_ddp:
+            scaling_params = [p for p in self.parameters() if p.requires_grad and isinstance(p, ScalingTensor)]
+            self.scaling_tensor_reducer = ScalingTensorReducer(scaling_params, self.process_group, self.bucket_bytes_cap)
+
+    def forward(self, *inputs, **kwargs):
+        if model_state.use_torch_ddp and torch.is_grad_enabled():
+            inputs = _DDPSink.apply(self.scaling_tensor_reducer, torch.tensor([], requires_grad=True), *inputs)
+        out = super().forward(*inputs, **kwargs)
+        return out
+
+torch.nn.parallel.DistributedDataParallel = FP8DistributedDataParallel

--- a/msamp/nn/distributed.py
+++ b/msamp/nn/distributed.py
@@ -236,9 +236,13 @@ class FP8DistributedDataParallel(torch.nn.parallel.DistributedDataParallel):
             kwargs (dict): The rest arguments for DistributedDataParallel.
         """
         super().__init__(module, **kwargs)
-        model_state.use_fp8_ddp = True
+
         scaling_params = [p for p in self.parameters() if p.requires_grad and isinstance(p, ScalingTensor)]
-        self.scaling_tensor_reducer = _ScalingTensorReducer(scaling_params, self.process_group, self.bucket_bytes_cap)
+        if len(scaling_params) > 0:
+            self.scaling_tensor_reducer = _ScalingTensorReducer(
+                scaling_params, self.process_group, self.bucket_bytes_cap
+            )
+            model_state.use_fp8_ddp = True
 
     def forward(self, *inputs, **kwargs):
         """Apply _DDPSink in forward function.

--- a/msamp/nn/distributed.py
+++ b/msamp/nn/distributed.py
@@ -11,7 +11,7 @@ import torch.distributed as dist
 from msamp.common.tensor import ScalingTensor, ScalingMeta
 from msamp.common.dtype import Dtypes, Floating
 from msamp.common.utils import TransformerEngineWrapper
-from msamp.nn import model_state
+from msamp.nn.state import model_state
 from msamp.operators.fp8_op import FP8Op
 
 

--- a/msamp/nn/distributed.py
+++ b/msamp/nn/distributed.py
@@ -236,7 +236,7 @@ class FP8DistributedDataParallel(torch.nn.parallel.DistributedDataParallel):
             kwargs (dict): The rest arguments for DistributedDataParallel.
         """
         super().__init__(module, **kwargs)
-        if model_state.use_torch_ddp:
+        if model_state.use_fp8_ddp:
             scaling_params = [p for p in self.parameters() if p.requires_grad and isinstance(p, ScalingTensor)]
             self.scaling_tensor_reducer = _ScalingTensorReducer(
                 scaling_params, self.process_group, self.bucket_bytes_cap
@@ -249,7 +249,7 @@ class FP8DistributedDataParallel(torch.nn.parallel.DistributedDataParallel):
             inputs (tuple): The input tensors.
             kwargs (dict): The keyword arguments.
         """
-        if model_state.use_torch_ddp and torch.is_grad_enabled():
+        if model_state.use_fp8_ddp and torch.is_grad_enabled():
             inputs = _DDPSink.apply(self.scaling_tensor_reducer, torch.tensor([], requires_grad=True), *inputs)
         out = super().forward(*inputs, **kwargs)
         return out

--- a/msamp/nn/distributed.py
+++ b/msamp/nn/distributed.py
@@ -61,13 +61,12 @@ class _ScalingTensorReducer:
         return torch.empty((buffer_size, ), dtype=torch.uint8, device=self.device)
 
     def _build_buckets(self, parameters):
-        """Split the parameters into muitple buckets in reverse order.
+        """Split the parameters into multiple buckets in reverse order.
 
         Args:
             parameters (list): A list of ScalingTensor.
         """
         bucket_bytes = 0
-        total_bytes = 0
         bucket_id = 0
         bucket_offset = 0
         param_id_to_bucket_id = {}
@@ -79,9 +78,9 @@ class _ScalingTensorReducer:
             param_id_to_bucket_id[param_id] = bucket_id
             bucket_to_param_ids.setdefault(bucket_id, []).append(param_id)
             bucket_bytes += nbytes
-            total_bytes += nbytes
             if bucket_bytes >= self.bucket_bytes_cap:
                 bucket_to_range[bucket_id] = (bucket_offset, bucket_offset + bucket_bytes)
+                bucket_offset += bucket_bytes
                 bucket_id += 1
                 bucket_bytes = 0
 

--- a/msamp/nn/functional.py
+++ b/msamp/nn/functional.py
@@ -97,7 +97,7 @@ class _FP8GemmFunction(torch.autograd.Function):
                 )
                 del old_wgrad
 
-            if model_state.use_torch_ddp:
+            if model_state.use_fp8_ddp:
                 wgrad.meta = wgrad_meta
             else:
                 # wgrad above this line is torch.Tensor w/o tensor scaling

--- a/msamp/nn/functional.py
+++ b/msamp/nn/functional.py
@@ -9,7 +9,7 @@ import torch.nn.functional as F
 from msamp.common.dtype import Dtypes
 from msamp.common.tensor import ScalingTensor
 from msamp.operators.gemm import Gemm
-from msamp.nn import model_state
+from msamp.nn.state import model_state
 
 
 class _FP8GemmFunction(torch.autograd.Function):

--- a/msamp/nn/functional.py
+++ b/msamp/nn/functional.py
@@ -9,7 +9,6 @@ import torch.nn.functional as F
 from msamp.common.dtype import Dtypes
 from msamp.common.tensor import ScalingTensor
 from msamp.operators.gemm import Gemm
-from msamp.common.utils import DistUtil
 from msamp.nn import model_state
 
 
@@ -98,10 +97,11 @@ class _FP8GemmFunction(torch.autograd.Function):
                 )
                 del old_wgrad
 
-            # wgrad above this line is torch.Tensor w/o tensor scaling
-            wgrad = wgrad.cast(Dtypes.kfloat8_e4m3, meta=wgrad_meta, sync=True)
-            if DistUtil.get_world_size() > 1:
-                model_state.ready_to_all_reduce_grads = True
+            if model_state.use_torch_ddp:
+                wgrad.meta = wgrad_meta
+            else:
+                # wgrad above this line is torch.Tensor w/o tensor scaling
+                wgrad = wgrad.cast(Dtypes.kfloat8_e4m3, meta=wgrad_meta, sync=True)
 
             ctx.weight.backward_grad_update(wgrad)
 

--- a/msamp/nn/linear.py
+++ b/msamp/nn/linear.py
@@ -176,7 +176,6 @@ class LinearReplacer:
         model = cls._replace(model, weight_qtype)
         fp8_named_weights = [(k, p) for k, p in model.named_parameters() if isinstance(p, ScalingParameter)]
 
-        # fp8_names = [k for k, _ in fp8_named_weights]
         fp8_weights = [p for _, p in fp8_named_weights]
         TensorDist.broadcast(fp8_weights, src=src_rank, group=group)
 

--- a/msamp/nn/linear.py
+++ b/msamp/nn/linear.py
@@ -189,8 +189,7 @@ class LinearReplacer:
         for module_name, module in model.named_modules():
             for param_name, param in module.named_parameters(recurse=False):
                 if isinstance(param, ScalingParameter):
-                    # Create expected format
-                    fqn = f"{module_name}.{param_name}"
+                    fqn = f'{module_name}.{param_name}'
                     fp8_names.append(fqn)
         torch.nn.parallel.DistributedDataParallel._set_params_and_buffers_to_ignore_for_model(model, fp8_names)
 

--- a/msamp/nn/state.py
+++ b/msamp/nn/state.py
@@ -14,7 +14,6 @@ class ModelState:
     def __init__(self):
         """Constructor."""
         self._ready_to_scale_tensor = False
-        self._ready_to_all_reduce_grads = False
         # dict[str, dict[str, tensor]], store the flattened scaling metas in all FP8Linear modules.
         # key in input/wgrad/output, value is a dict whose key is scales/amaxs/amax_counters
         # and value is flattened tensors.
@@ -22,6 +21,7 @@ class ModelState:
         # OrderedDict[str, dict[str, ScalingMeta]], store the local scaling metas in all FP8Linear modules.
         # key is module name, value is scaling_metas in FP8Linear module.
         self._local_scaling_metas = OrderedDict()
+        self._use_torch_ddp = False
 
     @property
     def ready_to_scale_tensor(self):
@@ -38,23 +38,23 @@ class ModelState:
         self._ready_to_scale_tensor = value
 
     @property
-    def ready_to_all_reduce_grads(self):
-        """Decoration function to access _ready_to_all_reduce_grads variable."""
-        return self._ready_to_all_reduce_grads
+    def flattened_scaling_metas(self):
+        """Decoration function to access _flattened_scaling_metas variable."""
+        return self._flattened_scaling_metas
 
-    @ready_to_all_reduce_grads.setter
-    def ready_to_all_reduce_grads(self, value):
-        """Set the value of _ready_to_all_reduce_grads variable.
+    @property
+    def use_torch_ddp(self):
+        """Decoration function to access _use_torch_ddp variable."""
+        return self._use_torch_ddp
+
+    @use_torch_ddp.setter
+    def use_torch_ddp(self, value):
+        """Set the value of _use_torch_ddp variable.
 
         Args:
             value (bool): Value to set.
         """
-        self._ready_to_all_reduce_grads = value
-
-    @property
-    def flattened_scaling_metas(self):
-        """Decoration function to access _flattened_scaling_metas variable."""
-        return self._flattened_scaling_metas
+        self._use_torch_ddp = value
 
     @flattened_scaling_metas.setter
     def flattened_scaling_metas(self, value):

--- a/msamp/nn/state.py
+++ b/msamp/nn/state.py
@@ -21,7 +21,7 @@ class ModelState:
         # OrderedDict[str, dict[str, ScalingMeta]], store the local scaling metas in all FP8Linear modules.
         # key is module name, value is scaling_metas in FP8Linear module.
         self._local_scaling_metas = OrderedDict()
-        self._use_torch_ddp = False
+        self._use_fp8_ddp = False
 
     @property
     def ready_to_scale_tensor(self):
@@ -43,18 +43,18 @@ class ModelState:
         return self._flattened_scaling_metas
 
     @property
-    def use_torch_ddp(self):
-        """Decoration function to access _use_torch_ddp variable."""
-        return self._use_torch_ddp
+    def use_fp8_ddp(self):
+        """Decoration function to access _use_fp8_ddp variable."""
+        return self._use_fp8_ddp
 
-    @use_torch_ddp.setter
-    def use_torch_ddp(self, value):
-        """Set the value of _use_torch_ddp variable.
+    @use_fp8_ddp.setter
+    def use_fp8_ddp(self, value):
+        """Set the value of _use_fp8_ddp variable.
 
         Args:
             value (bool): Value to set.
         """
-        self._use_torch_ddp = value
+        self._use_fp8_ddp = value
 
     @flattened_scaling_metas.setter
     def flattened_scaling_metas(self, value):

--- a/msamp/optim/optimizer.py
+++ b/msamp/optim/optimizer.py
@@ -44,7 +44,7 @@ class LBOptimizer(Optimizer):
 
     def all_reduce_grads(self, model):
         """All-reduce gradients of parameters."""
-        if model_state.use_torch_ddp:
+        if model_state.use_fp8_ddp:
             return
         scaling_params = [p for p in model.parameters() if isinstance(p, ScalingParameter)]
         grads = [p.grad for p in scaling_params if p.grad is not None]

--- a/msamp/optim/optimizer.py
+++ b/msamp/optim/optimizer.py
@@ -38,19 +38,17 @@ class LBOptimizer(Optimizer):
         Args:
             closure (callable, optional): A closure that reevaluates the model and returns the loss.
         """
-        assert not model_state.ready_to_all_reduce_grads, \
-            'Please call optimizer.all_reduce_grads(model) before calling optimizer.step()'
         rtn = self.lb_step(closure)
         self._update_scaling_factors()
         return rtn
 
     def all_reduce_grads(self, model):
         """All-reduce gradients of parameters."""
+        if model_state.use_torch_ddp:
+            return
         scaling_params = [p for p in model.parameters() if isinstance(p, ScalingParameter)]
         grads = [p.grad for p in scaling_params if p.grad is not None]
         TensorDist.all_reduce_avg(grads)
-        # make sure that FP8 weight gradients have been reduced.
-        model_state.ready_to_all_reduce_grads = False
 
     def lb_step(self, closure=None):
         """Performs a single optimization step. The subclass needs to implement this method.

--- a/tests/nn/test_distributed.py
+++ b/tests/nn/test_distributed.py
@@ -24,7 +24,8 @@ class FakeNet(nn.Module):
 
     def forward(self, x):
         return self.fc1(x)
-    
+
+
 class DistributedTestCast(MultiProcessTestCase):
     """Test functions in distributed module."""
     def setUp(self):
@@ -32,7 +33,6 @@ class DistributedTestCast(MultiProcessTestCase):
         torch.manual_seed(1000)
         super().setUp()
         self._spawn_processes()
-
 
     def tearDown(self):
         """Hook method for deconstructing the test fixture after testing it."""
@@ -57,14 +57,14 @@ class DistributedTestCast(MultiProcessTestCase):
         store = dist.FileStore(self.file_name, self.world_size)
         torch.cuda.set_device(rank)
         dist.init_process_group(backend='nccl', store=store, rank=self.rank, world_size=self.world_size)
-            
+
         fake_model = FakeNet().cuda()
         model = LinearReplacer.replace(fake_model)
-        
+
         with _ddp_replicated_tensor(False):
             model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[rank])
             assert isinstance(model, FP8DistributedDataParallel)
-            # input is different for each rank. 
+            # input is different for each rank.
             input = torch.randn(20, 10).cuda() + rank
             output = model(input)
             output.sum().backward()

--- a/tests/nn/test_distributed.py
+++ b/tests/nn/test_distributed.py
@@ -1,8 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for msamp.nn.distributed module."""
+
 import os
 
 import torch
 import torch.nn as nn
-
 import torch.distributed as dist
 from torch.nn.parallel._replicated_tensor_ddp_utils import _ddp_replicated_tensor
 from torch.testing._internal.common_distributed import MultiProcessTestCase, skip_if_lt_x_gpu, requires_nccl
@@ -11,7 +15,9 @@ from msamp.nn import LinearReplacer, model_state
 from msamp.nn.distributed import FP8DistributedDataParallel
 from tests.helper import decorator
 
+
 class FakeNet(nn.Module):
+    """A fake network for testing."""
     def __init__(self):
         super().__init__()
         self.fc1 = nn.Linear(10, 10)
@@ -20,7 +26,7 @@ class FakeNet(nn.Module):
         return self.fc1(x)
     
 class DistributedTestCast(MultiProcessTestCase):
-    """Test functions in clip_grad module."""
+    """Test functions in distributed module."""
     def setUp(self):
         """Hook method for setting up the test fixture before exercising it."""
         torch.manual_seed(1000)
@@ -45,6 +51,7 @@ class DistributedTestCast(MultiProcessTestCase):
     @skip_if_lt_x_gpu(2)
     @decorator.cuda_test
     def test_fp8_ddp(self):
+        """Test FP8DistributedDataParallel."""
         model_state.use_torch_ddp = True
         rank = self.rank
         store = dist.FileStore(self.file_name, self.world_size)

--- a/tests/nn/test_distributed.py
+++ b/tests/nn/test_distributed.py
@@ -19,10 +19,12 @@ from tests.helper import decorator
 class FakeNet(nn.Module):
     """A fake network for testing."""
     def __init__(self):
+        """Constructor."""
         super().__init__()
         self.fc1 = nn.Linear(10, 10)
 
     def forward(self, x):
+        """Forward function."""
         return self.fc1(x)
 
 

--- a/tests/nn/test_distributed.py
+++ b/tests/nn/test_distributed.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 import torch.distributed as dist
 from torch.testing._internal.common_distributed import MultiProcessTestCase, skip_if_lt_x_gpu, requires_nccl
 
-from msamp.nn import LinearReplacer, model_state
+from msamp.nn import LinearReplacer
 from msamp.nn.distributed import FP8DistributedDataParallel
 from tests.helper import decorator
 
@@ -53,7 +53,6 @@ class DistributedTestCast(MultiProcessTestCase):
     @decorator.cuda_test
     def test_fp8_ddp(self):
         """Test FP8DistributedDataParallel."""
-        model_state.use_fp8_ddp = True
         rank = self.rank
         store = dist.FileStore(self.file_name, self.world_size)
         torch.cuda.set_device(rank)
@@ -80,4 +79,3 @@ class DistributedTestCast(MultiProcessTestCase):
         expect_grad = self.world_size * fake_model.fc1.weight.grad.value.clone()
         dist.all_reduce(fake_model.fc1.weight.grad.value)
         assert torch.equal(expect_grad, fake_model.fc1.weight.grad.value)
-        model_state.use_fp8_ddp = False

--- a/tests/nn/test_distributed.py
+++ b/tests/nn/test_distributed.py
@@ -1,0 +1,69 @@
+import os
+
+import torch
+import torch.nn as nn
+
+import torch.distributed as dist
+from torch.nn.parallel._replicated_tensor_ddp_utils import _ddp_replicated_tensor
+from torch.testing._internal.common_distributed import MultiProcessTestCase, skip_if_lt_x_gpu, requires_nccl
+
+from msamp.nn import LinearReplacer, model_state
+from msamp.nn.distributed import FP8DistributedDataParallel
+from tests.helper import decorator
+
+class FakeNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(10, 10)
+
+    def forward(self, x):
+        return self.fc1(x)
+    
+class DistributedTestCast(MultiProcessTestCase):
+    """Test functions in clip_grad module."""
+    def setUp(self):
+        """Hook method for setting up the test fixture before exercising it."""
+        torch.manual_seed(1000)
+        super().setUp()
+        self._spawn_processes()
+
+
+    def tearDown(self):
+        """Hook method for deconstructing the test fixture after testing it."""
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    @property
+    def world_size(self):
+        """Return the number of processes."""
+        return 2
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    @decorator.cuda_test
+    def test_fp8_ddp(self):
+        model_state.use_torch_ddp = True
+        rank = self.rank
+        store = dist.FileStore(self.file_name, self.world_size)
+        torch.cuda.set_device(rank)
+        dist.init_process_group(backend='nccl', store=store, rank=self.rank, world_size=self.world_size)
+            
+        fake_model = FakeNet().cuda()
+        model = LinearReplacer.replace(fake_model)
+        
+        with _ddp_replicated_tensor(False):
+            model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[rank])
+            assert isinstance(model, FP8DistributedDataParallel)
+            # input is different for each rank. 
+            input = torch.randn(20, 10).cuda() + rank
+            output = model(input)
+            output.sum().backward()
+            assert fake_model.fc1.weight.grad.value.dtype == torch.uint8
+            # after backward, the grad should be same for each rank. And we call all_reduce to check it.
+            expect_grad = self.world_size * fake_model.fc1.weight.grad.value.clone()
+            dist.all_reduce(fake_model.fc1.weight.grad.value)
+            assert torch.equal(expect_grad, fake_model.fc1.weight.grad.value)
+        model_state.use_torch_ddp = False

--- a/tests/nn/test_linear.py
+++ b/tests/nn/test_linear.py
@@ -50,11 +50,11 @@ class LinearTestCase(unittest.TestCase):
         fp8linear(input).sum().backward()
 
         # check bias.
-        self.assertTrue(type(fp8linear.bias.grad) == torch.Tensor)
+        self.assertTrue(isinstance(fp8linear.bias.grad, torch.Tensor))
         self.assertTrue(torch.equal(fp8linear.bias.grad, linear.bias.grad))
 
         # check weight.
-        self.assertTrue(type(fp8linear.weight.grad) == ScalingTensor)
+        self.assertTrue(isinstance(fp8linear.weight.grad, ScalingTensor))
         self.assertTrue(fp8linear.weight.grad.size() == linear.weight.grad.size())
 
     @decorator.cuda_test

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -11,7 +11,7 @@ import torch
 from msamp.common.dtype import Dtypes
 from msamp.common.tensor import TensorDist
 from msamp.optim import LBAdamW, LBAdam, LBAdamWBase, DSAdam
-from msamp.nn import LinearReplacer, model_state
+from msamp.nn import LinearReplacer
 from tests.helper import decorator
 
 

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -95,10 +95,8 @@ class LBAdamwTestCase(unittest.TestCase):
         TensorDist.all_reduce_avg = debug_all_reduce_avg
         opt.all_reduce_grads(model1)
         self.assertEqual(num_grads, 1)
-        self.assertFalse(model_state.ready_to_all_reduce_grads)
         opt.all_reduce_grads(model2)
         self.assertEqual(num_grads, 2)
-        self.assertFalse(model_state.ready_to_all_reduce_grads)
         TensorDist.all_reduce_avg = old_all_reduce_avg
 
     def check_optimizer_state_dict(self, lbadam_class):


### PR DESCRIPTION
**Description**
Add custom ddp which supports fp8 and compute/communication overlap

**Major Revision**
- Add custom ddp which supports scaling tensor and compute/communication overlap
- Add UT for custom ddp
- Remove ready_to_all_reduce from model state

Test it use mnist_ddp:
```bash
torchrun --nproc_per_node=8 mnist_ddp.py --enable-msamp --opt-level=O2
```