### PR TITLE
[Bug Fixed] The scaling weight is not updated in the optimizer `LBAdamW`

### DIFF
--- a/msamp/optim/adamw.py
+++ b/msamp/optim/adamw.py
@@ -218,6 +218,14 @@ class LBAdamW(LBAdamWBase):
                 param, grad = param.float(), grads[i].float() if not maximize else -grads[i].float()
                 exp_avg_value, exp_avg_sq_value = exp_avgs[i]['state'], exp_avg_sqs[i]['state']
 
+                # Perform stepweight decay
+                # FP32/16 Tensor * float
+                if weight_decay != 0:
+                    if self.use_adam:
+                        grad = grad.add(param, alpha=weight_decay)
+                    else:
+                        param.mul_(1 - lr * weight_decay)
+
                 if self.bias_correction:
                     bias_correction1 = 1 - beta1**state_steps[i]
                     bias_correction2 = 1 - beta2**state_steps[i]

--- a/msamp/optim/adamw.py
+++ b/msamp/optim/adamw.py
@@ -238,3 +238,6 @@ class LBAdamW(LBAdamWBase):
                 # param = param - step_size * (exp_avg / denom)
                 # param.addcdiv_(exp_avg, denom, value=-step_size)
                 param.add_(exp_avg_value / denom, alpha=-step_size)
+
+                if isinstance(params[i], ScalingTensor):
+                    params[i].copy_(param.cast(params[i].qtype, meta=params[i].meta))

--- a/msamp/optim/adamw.py
+++ b/msamp/optim/adamw.py
@@ -173,8 +173,7 @@ class LBAdamW(LBAdamWBase):
             for i, param in enumerate(params):
                 param, grad = param.float(), grads[i].float() if not maximize else -grads[i].float()
 
-                # Perform stepweight decay
-                # FP32/16 Tensor * float
+                # Perform step weight decay
                 if weight_decay != 0:
                     if self.use_adam:
                         grad = grad.add(param, alpha=weight_decay)
@@ -218,8 +217,7 @@ class LBAdamW(LBAdamWBase):
                 param, grad = param.float(), grads[i].float() if not maximize else -grads[i].float()
                 exp_avg_value, exp_avg_sq_value = exp_avgs[i]['state'], exp_avg_sqs[i]['state']
 
-                # Perform stepweight decay
-                # FP32/16 Tensor * float
+                # Perform step weight decay
                 if weight_decay != 0:
                     if self.use_adam:
                         grad = grad.add(param, alpha=weight_decay)

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -8,6 +8,8 @@ import itertools
 import unittest
 import torch
 
+from functools import partial
+
 from msamp.common.dtype import Dtypes
 from msamp.common.tensor import TensorDist
 from msamp.optim import LBAdamW, LBAdam, LBAdamWBase, DSAdam
@@ -33,10 +35,10 @@ class LBAdamwTestCase(unittest.TestCase):
         for exp_avg_dtype, exp_avg_sq_dtype in pairs:
             with self.subTest(exp_avg_dtype=exp_avg_dtype, exp_avg_sq_dtype=exp_avg_sq_dtype):
                 kwargs = dict(exp_avg_dtype=exp_avg_dtype, exp_avg_sq_dtype=exp_avg_sq_dtype)
-                self.check_optimizer_step(LBAdamWBase, **kwargs)
-                self.check_optimizer_step(LBAdamW, **kwargs)
-                self.check_optimizer_step(LBAdam, **kwargs)
-                self.check_optimizer_step(DSAdam, **kwargs)
+                self.check_optimizer_step(torch.optim.AdamW, partial(LBAdamWBase, **kwargs))
+                self.check_optimizer_step(torch.optim.AdamW, partial(LBAdamW, **kwargs))
+                self.check_optimizer_step(torch.optim.Adam, partial(LBAdam, **kwargs))
+                self.check_optimizer_step(torch.optim.AdamW, partial(DSAdam, **kwargs))
 
     @decorator.cuda_test
     def test_state_dict(self):
@@ -44,19 +46,21 @@ class LBAdamwTestCase(unittest.TestCase):
         self.check_optimizer_state_dict(LBAdamW)
         self.check_optimizer_state_dict(LBAdam)
 
-    def check_optimizer_step(self, optimizer_class, diff=3e-4, **kwargs):
-        """Check the difference between torch.optim.AdamW and optimizer_class optimizers.
+    def check_optimizer_step(self, optimizer_class1, optimizer_class2, diff=3e-4):
+        """Check the difference between optimizer_class1 and optimizer_class2 optimizers.
 
         Args:
-            optimizer_class (class): LBAdamWBase, LBAdamW or LBAdam.
-            diff (float, optional): The difference between torch.optim.AdamW and optimizer_class optimizers.
+            optimizer_class1 (class): Optimizer Class
+            optimizer_class2 (class): Optimizer Class
+            diff (float, optional): The difference between optimizer_class1 and optimizer_class2 optimizers.
         """
         input = torch.randn(4, 4, device='cuda')
         linear = torch.nn.Linear(4, 4).cuda()
+        wd = 1e-3
 
         # test torch.optim.AdamW
         model1 = copy.deepcopy(linear)
-        opt1 = torch.optim.AdamW(model1.parameters())
+        opt1 = optimizer_class1(model1.parameters(), weight_decay=wd)
 
         for _ in range(4):
             output = model1(input)
@@ -68,7 +72,7 @@ class LBAdamwTestCase(unittest.TestCase):
         model2 = copy.deepcopy(linear)
         model2 = LinearReplacer.replace(model2, Dtypes.kfloat16)
 
-        opt2 = optimizer_class(model2.parameters(), **kwargs)
+        opt2 = optimizer_class2(model2.parameters(), weight_decay=wd)
 
         for _ in range(4):
             output = model2(input)

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -28,11 +28,9 @@ class LBAdamwTestCase(unittest.TestCase):
     @decorator.cuda_test
     def test_adamw_step(self):
         """Test adamw optimizer step function."""
-        for exp_avg_dtype, exp_avg_sq_dtype in [
-            (torch.float32, torch.float32),
-            (torch.float16, torch.float16),
-            (torch.uint8, torch.float16),
-        ]:
+        dtypes = [torch.uint8, torch.int8, torch.float16]
+        pairs = list(itertools.product(dtypes, dtypes)) + [[torch.float32, torch.float32]]
+        for exp_avg_dtype, exp_avg_sq_dtype in pairs:
             kwargs = dict(exp_avg_dtype=exp_avg_dtype, exp_avg_sq_dtype=exp_avg_sq_dtype)
             self.check_optimizer_step(LBAdamWBase, **kwargs)
             self.check_optimizer_step(LBAdamW, **kwargs)

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -31,11 +31,12 @@ class LBAdamwTestCase(unittest.TestCase):
         dtypes = [torch.uint8, torch.int8, torch.float16]
         pairs = list(itertools.product(dtypes, dtypes)) + [[torch.float32, torch.float32]]
         for exp_avg_dtype, exp_avg_sq_dtype in pairs:
-            kwargs = dict(exp_avg_dtype=exp_avg_dtype, exp_avg_sq_dtype=exp_avg_sq_dtype)
-            self.check_optimizer_step(LBAdamWBase, **kwargs)
-            self.check_optimizer_step(LBAdamW, **kwargs)
-            self.check_optimizer_step(LBAdam, **kwargs)
-            self.check_optimizer_step(DSAdam, **kwargs)
+            with self.subTest(exp_avg_dtype=exp_avg_dtype, exp_avg_sq_dtype=exp_avg_sq_dtype):
+                kwargs = dict(exp_avg_dtype=exp_avg_dtype, exp_avg_sq_dtype=exp_avg_sq_dtype)
+                self.check_optimizer_step(LBAdamWBase, **kwargs)
+                self.check_optimizer_step(LBAdamW, **kwargs)
+                self.check_optimizer_step(LBAdam, **kwargs)
+                self.check_optimizer_step(DSAdam, **kwargs)
 
     @decorator.cuda_test
     def test_state_dict(self):

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -28,10 +28,14 @@ class LBAdamwTestCase(unittest.TestCase):
     @decorator.cuda_test
     def test_adamw_step(self):
         """Test adamw optimizer step function."""
-        self.check_optimizer_step(LBAdamWBase)
-        self.check_optimizer_step(LBAdamW)
-        self.check_optimizer_step(LBAdam)
-        self.check_optimizer_step(DSAdam)
+        for exp_avg_dtype in [torch.float32, torch.float16, torch.uint8]:
+            for exp_avg_sq_dtype in [torch.float32, torch.float16]:
+                kwargs = dict(exp_avg_dtype=exp_avg_dtype, exp_avg_sq_dtype=exp_avg_sq_dtype)
+                self.check_optimizer_step(LBAdamWBase, **kwargs)
+                self.check_optimizer_step(LBAdamWBase, **kwargs)
+                self.check_optimizer_step(LBAdamW, **kwargs)
+                self.check_optimizer_step(LBAdam, **kwargs)
+                self.check_optimizer_step(DSAdam, **kwargs)
 
     @decorator.cuda_test
     def test_state_dict(self):
@@ -39,7 +43,7 @@ class LBAdamwTestCase(unittest.TestCase):
         self.check_optimizer_state_dict(LBAdamW)
         self.check_optimizer_state_dict(LBAdam)
 
-    def check_optimizer_step(self, optimizer_class, diff=3e-4):
+    def check_optimizer_step(self, optimizer_class, diff=3e-4, **kwargs):
         """Check the difference between torch.optim.AdamW and optimizer_class optimizers.
 
         Args:
@@ -63,7 +67,7 @@ class LBAdamwTestCase(unittest.TestCase):
         model2 = copy.deepcopy(linear)
         model2 = LinearReplacer.replace(model2, Dtypes.kfloat16)
 
-        opt2 = optimizer_class(model2.parameters())
+        opt2 = optimizer_class(model2.parameters(), **kwargs)
 
         for _ in range(4):
             output = model2(input)

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -35,7 +35,6 @@ class LBAdamwTestCase(unittest.TestCase):
         ]:
             kwargs = dict(exp_avg_dtype=exp_avg_dtype, exp_avg_sq_dtype=exp_avg_sq_dtype)
             self.check_optimizer_step(LBAdamWBase, **kwargs)
-            self.check_optimizer_step(LBAdamWBase, **kwargs)
             self.check_optimizer_step(LBAdamW, **kwargs)
             self.check_optimizer_step(LBAdam, **kwargs)
             self.check_optimizer_step(DSAdam, **kwargs)

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -28,14 +28,17 @@ class LBAdamwTestCase(unittest.TestCase):
     @decorator.cuda_test
     def test_adamw_step(self):
         """Test adamw optimizer step function."""
-        for exp_avg_dtype in [torch.float32, torch.float16, torch.uint8]:
-            for exp_avg_sq_dtype in [torch.float32, torch.float16]:
-                kwargs = dict(exp_avg_dtype=exp_avg_dtype, exp_avg_sq_dtype=exp_avg_sq_dtype)
-                self.check_optimizer_step(LBAdamWBase, **kwargs)
-                self.check_optimizer_step(LBAdamWBase, **kwargs)
-                self.check_optimizer_step(LBAdamW, **kwargs)
-                self.check_optimizer_step(LBAdam, **kwargs)
-                self.check_optimizer_step(DSAdam, **kwargs)
+        for exp_avg_dtype, exp_avg_sq_dtype in [
+            (torch.float32, torch.float32),
+            (torch.float16, torch.float16),
+            (torch.uint8, torch.float16),
+        ]:
+            kwargs = dict(exp_avg_dtype=exp_avg_dtype, exp_avg_sq_dtype=exp_avg_sq_dtype)
+            self.check_optimizer_step(LBAdamWBase, **kwargs)
+            self.check_optimizer_step(LBAdamWBase, **kwargs)
+            self.check_optimizer_step(LBAdamW, **kwargs)
+            self.check_optimizer_step(LBAdam, **kwargs)
+            self.check_optimizer_step(DSAdam, **kwargs)
 
     @decorator.cuda_test
     def test_state_dict(self):


### PR DESCRIPTION
**Description**
When the parameter is stored as a ScalingTensor, it can not be updated in the optimizer `LBAdamW` when `exp_avg_dtype is torch.float32` and `exp_avg_sq_dtype is torch.float32`.