### PR TITLE
[Bugfix] when parameters has no grad or ScalingParameter has no is_meta property it will crash

### DIFF
--- a/msamp/common/tensor/tensor.py
+++ b/msamp/common/tensor/tensor.py
@@ -418,6 +418,15 @@ meta.dtype is {meta_dtype} (meta.qtype is {meta.qtype}).'
         return self.value.shape
 
     @property
+    def is_meta(self):
+        """Return is_meta property of tensor.
+
+        Return:
+            bool: the is_meta property of value tensor.
+        """
+        return self.value.is_meta
+
+    @property
     def size(self):
         """Return size function of tensor.
 

--- a/msamp/deepspeed/runtime/engine.py
+++ b/msamp/deepspeed/runtime/engine.py
@@ -319,7 +319,7 @@ class MSAMPDeepSpeedEngine(DeepSpeedEngine):
                 # sense in the future to support the ability to average not
                 # w.r.t. world size but with a different value.
                 if isinstance(param, ScalingTensor):
-                    meta = ScalingMeta(Dtypes.kfloat8_e4m3)
+                    meta = ScalingMeta(Dtypes.dtype_to_qtype[param.dtype])
                     param.grad = ScalingTensor(torch.zeros(param.size(), dtype=param.dtype, device=param.device), meta)
                 else:
                     param.grad = torch.zeros(param.size(), dtype=param.dtype, device=param.device)
@@ -469,4 +469,3 @@ class MSAMPDeepSpeedEngine(DeepSpeedEngine):
     def msamp_optlevel(self):
         """Return the opt level of MS-AMP."""
         return self._config.msamp_optlevel
-

--- a/msamp/deepspeed/runtime/engine.py
+++ b/msamp/deepspeed/runtime/engine.py
@@ -336,7 +336,7 @@ class MSAMPDeepSpeedEngine(DeepSpeedEngine):
                 non_expert_grads.append(grad_data)
 
         return non_expert_grads, expert_grads
-    
+
     @instrument_w_nvtx
     def backward(      # noqa: C901
         self,

--- a/msamp/deepspeed/runtime/engine.py
+++ b/msamp/deepspeed/runtime/engine.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0. DeepSpeed Team)
 
 """DeepSpeedEngine in MS-AMP."""
+
 import torch
 import deepspeed
 from deepspeed.runtime.engine import SparseTensor, ZERO_OPTIMIZATION, AMP, amp, \

--- a/msamp/deepspeed/runtime/engine.py
+++ b/msamp/deepspeed/runtime/engine.py
@@ -4,14 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0. DeepSpeed Team)
 
 """DeepSpeedEngine in MS-AMP."""
+import torch
 import deepspeed
 from deepspeed.runtime.engine import SparseTensor, ZERO_OPTIMIZATION, AMP, amp, \
                                      FP16, BFLOAT16, logger, DeepSpeedEngine, instrument_w_nvtx, log_dist, \
                                      see_memory_usage, DummyOptim, DeepSpeedZeroOptimizer, DeepSpeedZeRoOffload, \
                                      PipelineModule, ZeroStageEnum
+from deepspeed.moe.utils import is_moe_param
 
 from msamp import initialize as msamp_initialize
-from msamp.common.tensor import ScalingTensor, TensorDist
+from msamp.common.dtype import Dtypes
+from msamp.common.tensor import ScalingTensor, TensorDist, ScalingMeta
 from msamp.optim import LBOptimizer
 from msamp.deepspeed.runtime.fp8.fused_optimizer import FP8Optimizer
 from msamp.deepspeed.runtime.zero import utils    # noqa: F401
@@ -301,6 +304,38 @@ class MSAMPDeepSpeedEngine(DeepSpeedEngine):
 
         return optimizer
 
+    def _get_gradients_for_reduction(self):
+        non_expert_grads = []
+        expert_grads = {}
+        if self.has_moe_layers:
+            for key in self.expert_data_parallel_group.keys():
+                expert_grads[key] = []
+
+        for param_name, param in self.module.named_parameters():
+            if param.grad is None:
+                # In cases where there is an imbalance of empty grads across
+                # ranks we must create empty grads, this will ensure that every
+                # rank is reducing the same size. In some cases it may make
+                # sense in the future to support the ability to average not
+                # w.r.t. world size but with a different value.
+                if isinstance(param, ScalingTensor):
+                    meta = ScalingMeta(Dtypes.kfloat8_e4m3)
+                    param.grad = ScalingTensor(torch.zeros(param.size(), dtype=param.dtype, device=param.device), meta)
+                else:
+                    param.grad = torch.zeros(param.size(), dtype=param.dtype, device=param.device)
+
+            grad_data = param.grad.data
+            if param_name in self.sparse_tensor_module_names or grad_data.is_sparse:
+                # Call param.grad without data to avoid problem with setting of updated grads
+                grad_data = SparseTensor(param.grad)
+
+            if is_moe_param(param):
+                expert_grads[param.group_name].append(grad_data)
+            else:
+                non_expert_grads.append(grad_data)
+
+        return non_expert_grads, expert_grads
+    
     @instrument_w_nvtx
     def backward(      # noqa: C901
         self,
@@ -434,3 +469,4 @@ class MSAMPDeepSpeedEngine(DeepSpeedEngine):
     def msamp_optlevel(self):
         """Return the opt level of MS-AMP."""
         return self._config.msamp_optlevel
+

--- a/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
+++ b/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
@@ -46,10 +46,7 @@ class FP8DeepSpeedZeroOptimizer(DeepSpeedZeroOptimizer):
                     hp_params.append(p)
             self.fp8_param_groups.append(fp8_params)
 
-            if len(hp_params) == 0:
-                init_optimizer.param_groups.remove(pg)
-            else:
-                pg['params'] = hp_params
+            pg['params'] = hp_params
 
         assert len(self.fp8_param_groups) == len(init_optimizer.param_groups)
 

--- a/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
+++ b/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
@@ -45,7 +45,11 @@ class FP8DeepSpeedZeroOptimizer(DeepSpeedZeroOptimizer):
                 else:
                     hp_params.append(p)
             self.fp8_param_groups.append(fp8_params)
-            pg['params'] = hp_params
+
+            if len(hp_params) == 0:
+                init_optimizer.param_groups.remove(pg)
+            else:
+                pg['params'] = hp_params
 
         assert len(self.fp8_param_groups) == len(init_optimizer.param_groups)
 

--- a/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
+++ b/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
@@ -45,7 +45,6 @@ class FP8DeepSpeedZeroOptimizer(DeepSpeedZeroOptimizer):
                 else:
                     hp_params.append(p)
             self.fp8_param_groups.append(fp8_params)
-
             pg['params'] = hp_params
 
         assert len(self.fp8_param_groups) == len(init_optimizer.param_groups)

--- a/tests/deepspeed/test_engine.py
+++ b/tests/deepspeed/test_engine.py
@@ -174,6 +174,10 @@ class DeepSpeedEngineTestCase(unittest.TestCase):
         }
         model, _, _, _ = deepspeed.initialize(model=model, config=config)
 
+        for name, param in model.module.named_parameters():
+            if name.startswith('1.'):
+                param.requires_grad = False
+
         inputs = []
         num_inputs = 10
         for _ in range(num_inputs):


### PR DESCRIPTION
**Description**
Fix some bugs reported by 1P customers:
- When some parameters have no gradient, _get_gradients_for_reduction will create a torch.cuda.ByteTensor for gradient, which is not supported in split_half_float_double_sparse.
- In [pytorch 2.1](https://github.com/pytorch/pytorch/blob/v2.1.0/torch/nn/modules/module.py#L2024), it will call param.is_meta, which does not exist in ScalingParameter and will crash.