### PR TITLE
[Bugfix] LinearReplacer.replace(linear, Dtypes.kbfloat16) raises error.

### DIFF
--- a/msamp/nn/linear.py
+++ b/msamp/nn/linear.py
@@ -86,6 +86,7 @@ class LinearReplacer:
             in_features=linear.in_features,
             out_features=linear.out_features,
             use_bias=linear.bias is not None,
+            weight_qtype=weight_qtype,
             bias_type=bias_dtype
         ).cuda()
 

--- a/tests/nn/test_linear.py
+++ b/tests/nn/test_linear.py
@@ -29,13 +29,14 @@ class LinearTestCase(unittest.TestCase):
         """Test FP8LInear forward function."""
         input = torch.randn((4, 4), device='cuda')
         linear = torch.nn.Linear(4, 8).cuda()
-        model = LinearReplacer.replace(linear, Dtypes.kfloat16)
+        for qtype in [Dtypes.float32, Dtypes.kfloat16, Dtypes.kbfloat16]:
+            model = LinearReplacer.replace(linear, qtype)
 
-        output = linear(input)
-        fp8_output = model(input)
-        self.assertTrue(fp8_output.dtype == torch.float)
-        self.assertTrue(fp8_output.size() == torch.Size((4, 8)))
-        self.assertTrue(torch.allclose(output, fp8_output, 0, 0.1))
+            output = linear(input)
+            fp8_output = model(input)
+            self.assertTrue(fp8_output.dtype == torch.float32)
+            self.assertTrue(fp8_output.size() == torch.Size((4, 8)))
+            self.assertTrue(torch.allclose(output, fp8_output, 0, 0.1))
 
     @decorator.cuda_test
     def test_fp8linear_backward(self):
@@ -46,16 +47,17 @@ class LinearTestCase(unittest.TestCase):
 
         linear(input).sum().backward()
 
-        fp8linear = LinearReplacer.replace(linear_copy, Dtypes.kfloat16)
-        fp8linear(input).sum().backward()
+        for qtype in [Dtypes.float32, Dtypes.kfloat16, Dtypes.kbfloat16]:
+            fp8linear = LinearReplacer.replace(linear_copy, qtype)
+            fp8linear(input).sum().backward()
 
-        # check bias.
-        self.assertTrue(isinstance(fp8linear.bias.grad, torch.Tensor))
-        self.assertTrue(torch.equal(fp8linear.bias.grad, linear.bias.grad))
+            # check bias.
+            self.assertTrue(isinstance(fp8linear.bias.grad, torch.Tensor))
+            self.assertTrue(torch.equal(fp8linear.bias.grad, linear.bias.grad))
 
-        # check weight.
-        self.assertTrue(isinstance(fp8linear.weight.grad, ScalingTensor))
-        self.assertTrue(fp8linear.weight.grad.size() == linear.weight.grad.size())
+            # check weight.
+            self.assertTrue(isinstance(fp8linear.weight.grad, ScalingTensor))
+            self.assertTrue(fp8linear.weight.grad.size() == linear.weight.grad.size())
 
     @decorator.cuda_test
     def test_fp8linear_accu_grad(self):

--- a/tests/nn/test_linear.py
+++ b/tests/nn/test_linear.py
@@ -29,7 +29,7 @@ class LinearTestCase(unittest.TestCase):
         """Test FP8LInear forward function."""
         input = torch.randn((4, 4), device='cuda')
         linear = torch.nn.Linear(4, 8).cuda()
-        for qtype in [Dtypes.float32, Dtypes.kfloat16, Dtypes.kbfloat16]:
+        for qtype in [Dtypes.kfloat32, Dtypes.kfloat16, Dtypes.kbfloat16]:
             model = LinearReplacer.replace(linear, qtype)
 
             output = linear(input)
@@ -47,7 +47,7 @@ class LinearTestCase(unittest.TestCase):
 
         linear(input).sum().backward()
 
-        for qtype in [Dtypes.float32, Dtypes.kfloat16, Dtypes.kbfloat16]:
+        for qtype in [Dtypes.kfloat32, Dtypes.kfloat16, Dtypes.kbfloat16]:
             fp8linear = LinearReplacer.replace(linear_copy, qtype)
             fp8linear(input).sum().backward()
 


### PR DESCRIPTION
**Description**
When replacing the weight with ScalingBF16, it will raise the following error.
```
Traceback (most recent call last):
  File "test_code.py", line 9, in <module>
    model = LinearReplacer.replace(linear, qtype)
  File "/usr/local/lib/python3.8/dist-packages/msamp/nn/linear.py", line 176, in replace
    model = cls._replace(model, weight_qtype)
  File "/usr/local/lib/python3.8/dist-packages/msamp/nn/linear.py", line 154, in _replace
    fp8_net = cls._build_fp8linear(model, weight_qtype)
  File "/usr/local/lib/python3.8/dist-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/msamp/nn/linear.py", line 100, in _build_fp8linear
    raise ValueError(
ValueError: weight dtype is not same, dtype ins fp8 linear is torch.float16,dtype in weight is torch.bfloat16

```
Reproduce code:
```python
import torch

from msamp.common.dtype import Dtypes
from msamp.nn import LinearReplacer

input = torch.randn((4, 4), device='cuda')
linear = torch.nn.Linear(4, 8).cuda()
qtype = Dtypes.kbfloat16
model = LinearReplacer.replace(linear, qtype)

```

The reason is that LinearReplacer did not pass the argument `weight_qtype` in FP8Linear, so `weight_qtype` is the default value `Dtypes.float16`, even if calling `LinearReplacer.replace(linear, Dtypes.kbfloat16)`.

**Major Revision**
- pass the argument `weight_qtype`
- unittest