### PR TITLE
[Dependencies] update deepspeed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "transformer-engine@git+https://github.com/NVIDIA/TransformerEngine.git@v0.11#egg=transformer-engine",
     "flash-attn==1.0.9",
     "colorlog>=6.7.0",
-    "deepspeed==0.9.2",
+    "deepspeed==0.12.3",
     "mpi4py",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
**Description**
I have checked that MS-AMP is compatible with the latest deepspeed (0.12.3).

**Major Revision**
- The version of deepspeed (0.9.2 -> 0.12.3)

Related Issue: #129 