### PR TITLE
Use ScalingTensor for state in AdamW optimizer

### DIFF
--- a/msamp/optim/adamw.py
+++ b/msamp/optim/adamw.py
@@ -151,8 +151,10 @@ class LBAdamW(LBAdamWBase):
             _exp_avg_sq_inv_factors = [1.0 / exp_avg_sq.meta.scale for exp_avg_sq in exp_avg_sqs]
             torch._foreach_zero_(_exp_avg_amaxs)
             torch._foreach_zero_(_exp_avg_sq_amaxs)
+
             for i, param in enumerate(params):
                 param, grad = param.float(), grads[i].float() if not maximize else -grads[i].float()
+
                 # Perform step weight decay
                 if weight_decay != 0:
                     if self.use_adam:

--- a/msamp/optim/adamw.py
+++ b/msamp/optim/adamw.py
@@ -105,24 +105,6 @@ class LBAdamW(LBAdamWBase):
             exp_avg_sq_dtype=exp_avg_sq_dtype
         )
 
-    def _get_state_tensor(self, state, dtype):
-        """Get state dict from tensor and dtype.
-
-        Convert state to dtype since the caller in LBAdamWBase always pass state as a float32 tensor.
-
-        Args:
-            state (Tensor): state tensor.
-            dtype (torch.dtype): dtype of the state tensor.
-
-        Return:
-            dict: state dict contains state tensor and other scaling meta data if not float32.
-        """
-        state = state.to(dtype=dtype)
-
-        if dtype != torch.float32:
-            return dict(state=state, factor=1.0, amax=state.new_zeros((1, ), dtype=torch.float32))
-        return dict(state=state)
-
     def adamw_fn(   # noqa: C901
         self,
         params: List[Union[Tensor, ScalingTensor]],
@@ -162,31 +144,28 @@ class LBAdamW(LBAdamWBase):
         if amsgrad:
             raise ValueError('Only amsgrad=False is supported for now.')
 
-        if len(exp_avgs) > 0 and exp_avgs[0]['state'].dtype != torch.float32:
-            _exp_avg_amaxs = [exp_avg['amax'] for exp_avg in exp_avgs]
-            _exp_avg_sq_amaxs = [exp_avg_sq['amax'] for exp_avg_sq in exp_avg_sqs]
-            _exp_avg_inv_factors = [1.0 / exp_avg['factor'] for exp_avg in exp_avgs]
-            _exp_avg_sq_inv_factors = [1.0 / exp_avg_sq['factor'] for exp_avg_sq in exp_avg_sqs]
+        if len(exp_avgs) > 0 and exp_avgs[0].dtype != torch.float32:
+            _exp_avg_amaxs = [exp_avg.meta.amax for exp_avg in exp_avgs]
+            _exp_avg_sq_amaxs = [exp_avg_sq.meta.amax for exp_avg_sq in exp_avg_sqs]
+            _exp_avg_inv_factors = [1.0 / exp_avg.meta.scale for exp_avg in exp_avgs]
+            _exp_avg_sq_inv_factors = [1.0 / exp_avg_sq.meta.scale for exp_avg_sq in exp_avg_sqs]
             torch._foreach_zero_(_exp_avg_amaxs)
             torch._foreach_zero_(_exp_avg_sq_amaxs)
-
             for i, param in enumerate(params):
                 param, grad = param.float(), grads[i].float() if not maximize else -grads[i].float()
-
                 # Perform step weight decay
                 if weight_decay != 0:
                     if self.use_adam:
                         grad = grad.add(param, alpha=weight_decay)
                     else:
                         param.mul_(1 - lr * weight_decay)
-
                 assert param.is_contiguous()
                 assert grad.is_contiguous()
 
                 msamp_adamw.adamw_fp8_stage1_compute(
-                    param, grad, exp_avgs[i]['state'], _exp_avg_inv_factors[i], _exp_avg_amaxs[i], beta1,
-                    exp_avg_sqs[i]['state'], _exp_avg_sq_inv_factors[i], _exp_avg_sq_amaxs[i], beta2, eps,
-                    state_steps[i], lr, self.bias_correction
+                    param, grad, exp_avgs[i].value, _exp_avg_inv_factors[i], _exp_avg_amaxs[i], beta1,
+                    exp_avg_sqs[i].value, _exp_avg_sq_inv_factors[i], _exp_avg_sq_amaxs[i], beta2, eps, state_steps[i],
+                    lr, self.bias_correction
                 )
                 if isinstance(params[i], ScalingTensor):
                     params[i].copy_(param.cast(params[i].qtype, meta=params[i].meta))
@@ -195,27 +174,27 @@ class LBAdamW(LBAdamWBase):
                 amaxs, sq_amaxs = torch.cat(_exp_avg_amaxs), torch.cat(_exp_avg_sq_amaxs)
                 ones = amaxs.new_ones((1, ))
                 _new_exp_avg_factors = ScalingMeta.compute_scaling_factor(
-                    amaxs, ones, Floating.fp_maxs[exp_avgs[0]['state'].dtype], 0
+                    amaxs, ones, Floating.fp_maxs[exp_avgs[0].dtype], 0
                 ).tolist()
                 _new_exp_avg_sq_factors = ScalingMeta.compute_scaling_factor(
-                    sq_amaxs, ones, Floating.fp_maxs[exp_avg_sqs[0]['state'].dtype], 0
+                    sq_amaxs, ones, Floating.fp_maxs[exp_avg_sqs[0].dtype], 0
                 ).tolist()
 
             for i, param in enumerate(params):
                 grad = grads[i].float() if not maximize else -grads[i].float()
-                exp_avgs[i]['factor'] = _new_exp_avg_factors[i] if self.tensor_scale else 1.0
-                exp_avg_sqs[i]['factor'] = _new_exp_avg_sq_factors[i] if self.tensor_scale else 1.0
+                exp_avgs[i].meta.scale = _new_exp_avg_factors[i] if self.tensor_scale else 1.0
+                exp_avg_sqs[i].meta.scale = _new_exp_avg_sq_factors[i] if self.tensor_scale else 1.0
                 # update state
                 msamp_adamw.adamw_fp8_stage2_compute(
-                    grad, exp_avgs[i]['state'], _exp_avg_inv_factors[i], exp_avgs[i]['factor'], beta1,
-                    exp_avg_sqs[i]['state'], _exp_avg_sq_inv_factors[i], exp_avg_sqs[i]['factor'], beta2,
-                    state_steps[i], self.bias_correction
+                    grad, exp_avgs[i].value, _exp_avg_inv_factors[i], exp_avgs[i].meta.scale, beta1,
+                    exp_avg_sqs[i].value, _exp_avg_sq_inv_factors[i], exp_avg_sqs[i].meta.scale, beta2, state_steps[i],
+                    self.bias_correction
                 )
         else:
             # float
             for i, param in enumerate(params):
                 param, grad = param.float(), grads[i].float() if not maximize else -grads[i].float()
-                exp_avg_value, exp_avg_sq_value = exp_avgs[i]['state'], exp_avg_sqs[i]['state']
+                exp_avg_value, exp_avg_sq_value = exp_avgs[i], exp_avg_sqs[i]
 
                 # Perform step weight decay
                 if weight_decay != 0:

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -11,7 +11,7 @@ import torch
 from functools import partial
 
 from msamp.common.dtype import Dtypes
-from msamp.common.tensor import TensorDist
+from msamp.common.tensor import TensorDist, ScalingTensor
 from msamp.optim import LBAdamW, LBAdam, LBAdamWBase, DSAdam
 from msamp.nn import LinearReplacer
 from tests.helper import decorator
@@ -141,11 +141,11 @@ class LBAdamwTestCase(unittest.TestCase):
         self.assertEqual(state[0]['step'], 4)
 
         for i in range(0, 2):
-            exp_avg = state[i]['exp_avg']['state']
-            self.assertEqual(type(exp_avg), torch.Tensor)
+            exp_avg = state[i]['exp_avg']
+            self.assertEqual(type(exp_avg), ScalingTensor)
             self.assertEqual(exp_avg.dtype, torch.uint8)
-            exp_avg_sq = state[0]['exp_avg_sq']['state']
-            self.assertEqual(type(exp_avg_sq), torch.Tensor)
+            exp_avg_sq = state[i]['exp_avg_sq']
+            self.assertEqual(type(exp_avg_sq), ScalingTensor)
             self.assertEqual(exp_avg_sq.dtype, torch.float16)
 
         param_groups = state_dict1['param_groups']


### PR DESCRIPTION
**Description**
Currently AdamW optimizer use dict for state, which is not reasonable. 
This PR change state from dict to ScalingTensor.

**Major Revision**
- Use ScalingTensor for state in AdamW
- Update UT
