### PR TITLE
fix bug in deep fp8 zero

### DIFF
--- a/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
+++ b/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
@@ -54,7 +54,8 @@ class FP8DeepSpeedZeroOptimizer(DeepSpeedZeroOptimizer):
                 else:
                     hp_params.append(p)
             self.fp8_param_groups.append(fp8_params)
-            # DeepSpeedZeroOptimizer will crash if there is no parameters in any parameter group, so add a fake parameter.
+            # DeepSpeedZeroOptimizer will crash if there is no parameters in any parameter group,
+            # so add a fake parameter.
             if len(hp_params) == 0:
                 param_names = args[0]
                 param_names[fake_param] = 'fake_' + str(fake_index)

--- a/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
+++ b/msamp/deepspeed/runtime/zero/fp8_stage_1_and_2.py
@@ -54,6 +54,7 @@ class FP8DeepSpeedZeroOptimizer(DeepSpeedZeroOptimizer):
                 else:
                     hp_params.append(p)
             self.fp8_param_groups.append(fp8_params)
+            # DeepSpeedZeroOptimizer will crash if there is no parameters in any parameter group, so add a fake parameter.
             if len(hp_params) == 0:
                 param_names = args[0]
                 param_names[fake_param] = 'fake_' + str(fake_index)
@@ -158,7 +159,6 @@ class FP8DeepSpeedZeroOptimizer(DeepSpeedZeroOptimizer):
             if len(partition) > 0:
                 ref_value = partition[0]
                 break
-        assert ref_value
         dtype = ref_value.dtype
         assert all(v.dtype == dtype for v in chain(*values_partitions))
 


### PR DESCRIPTION
**Description**
Fix 2 bugs in fp8 zero optimizer.
MS-AMP will crash when:
- there are param groups which don't have high precision parameter
-  partition 0 has no parameters.

