### PR TITLE
Remove model_state.use_fp8_ddp and optimizer.all_reduce_grads

### DIFF
--- a/msamp/nn/distributed.py
+++ b/msamp/nn/distributed.py
@@ -11,7 +11,6 @@ import torch.distributed as dist
 from msamp.common.tensor import ScalingTensor, ScalingMeta
 from msamp.common.dtype import Dtypes, Floating
 from msamp.common.utils import TransformerEngineWrapper
-from msamp.nn.state import model_state
 from msamp.operators.dist_op import DistOp
 
 

--- a/msamp/nn/distributed.py
+++ b/msamp/nn/distributed.py
@@ -246,7 +246,6 @@ class FP8DistributedDataParallel(torch.nn.parallel.DistributedDataParallel):
             self.scaling_tensor_reducer = _ScalingTensorReducer(
                 scaling_params, self.process_group, self.bucket_bytes_cap
             )
-            model_state.use_fp8_ddp = True
 
     def forward(self, *inputs, **kwargs):
         """Apply _DDPSink in forward function.
@@ -255,7 +254,7 @@ class FP8DistributedDataParallel(torch.nn.parallel.DistributedDataParallel):
             inputs (tuple): The input tensors.
             kwargs (dict): The keyword arguments.
         """
-        if model_state.use_fp8_ddp and torch.is_grad_enabled():
+        if torch.is_grad_enabled():
             inputs = _DDPSink.apply(self.scaling_tensor_reducer, torch.tensor([], requires_grad=True), *inputs)
         out = super().forward(*inputs, **kwargs)
         return out

--- a/msamp/nn/functional.py
+++ b/msamp/nn/functional.py
@@ -97,11 +97,7 @@ class _FP8GemmFunction(torch.autograd.Function):
                 )
                 del old_wgrad
 
-            if model_state.use_fp8_ddp:
-                wgrad.meta = wgrad_meta
-            else:
-                # wgrad above this line is torch.Tensor w/o tensor scaling
-                wgrad = wgrad.cast(Dtypes.kfloat8_e4m3, meta=wgrad_meta, sync=True)
+            wgrad.meta = wgrad_meta
 
             ctx.weight.backward_grad_update(wgrad)
 

--- a/msamp/nn/linear.py
+++ b/msamp/nn/linear.py
@@ -183,8 +183,8 @@ class LinearReplacer:
         for k, p in fp8_named_weights:
             p._param_name = k
 
-        # DDP ignores the FP8 weights, and the optimizer provides a function `optimizer.all_reduce_grads(model)`
-        # to sync them.
+        # The native DDP ignores the FP8 weights,
+        # and msamp.nn.distributed.FP8DistributedDataParallel will handle them.
         fp8_names = []
         for module_name, module in model.named_modules():
             for param_name, param in module.named_parameters(recurse=False):

--- a/msamp/nn/state.py
+++ b/msamp/nn/state.py
@@ -21,7 +21,6 @@ class ModelState:
         # OrderedDict[str, dict[str, ScalingMeta]], store the local scaling metas in all FP8Linear modules.
         # key is module name, value is scaling_metas in FP8Linear module.
         self._local_scaling_metas = OrderedDict()
-        self._use_fp8_ddp = False
 
     @property
     def ready_to_scale_tensor(self):
@@ -41,20 +40,6 @@ class ModelState:
     def flattened_scaling_metas(self):
         """Decoration function to access _flattened_scaling_metas variable."""
         return self._flattened_scaling_metas
-
-    @property
-    def use_fp8_ddp(self):
-        """Decoration function to access _use_fp8_ddp variable."""
-        return self._use_fp8_ddp
-
-    @use_fp8_ddp.setter
-    def use_fp8_ddp(self, value):
-        """Set the value of _use_fp8_ddp variable.
-
-        Args:
-            value (bool): Value to set.
-        """
-        self._use_fp8_ddp = value
 
     @flattened_scaling_metas.setter
     def flattened_scaling_metas(self, value):

--- a/msamp/optim/optimizer.py
+++ b/msamp/optim/optimizer.py
@@ -13,8 +13,7 @@ from torch.optim.optimizer import Optimizer, required
 
 from msamp.common.dtype import Floating
 from msamp.common.tensor import ScalingTensor, ScalingMeta
-from msamp.common.tensor import TensorDist
-from msamp.nn import model_state, ScalingParameter
+from msamp.nn import model_state
 
 
 class LBOptimizer(Optimizer):

--- a/msamp/optim/optimizer.py
+++ b/msamp/optim/optimizer.py
@@ -42,14 +42,6 @@ class LBOptimizer(Optimizer):
         self._update_scaling_factors()
         return rtn
 
-    def all_reduce_grads(self, model):
-        """All-reduce gradients of parameters."""
-        if model_state.use_fp8_ddp:
-            return
-        scaling_params = [p for p in model.parameters() if isinstance(p, ScalingParameter)]
-        grads = [p.grad for p in scaling_params if p.grad is not None]
-        TensorDist.all_reduce_avg(grads)
-
     def lb_step(self, closure=None):
         """Performs a single optimization step. The subclass needs to implement this method.
 

--- a/tests/nn/test_linear.py
+++ b/tests/nn/test_linear.py
@@ -56,7 +56,7 @@ class LinearTestCase(unittest.TestCase):
             self.assertTrue(torch.equal(fp8linear.bias.grad, linear.bias.grad))
 
             # check weight.
-            self.assertTrue(isinstance(fp8linear.weight.grad, ScalingTensor))
+            self.assertTrue(isinstance(fp8linear.weight.grad, torch.Tensor))
             self.assertTrue(fp8linear.weight.grad.size() == linear.weight.grad.size())
 
     @decorator.cuda_test

--- a/tests/optim/test_adamw.py
+++ b/tests/optim/test_adamw.py
@@ -11,7 +11,7 @@ import torch
 from functools import partial
 
 from msamp.common.dtype import Dtypes
-from msamp.common.tensor import TensorDist, ScalingTensor
+from msamp.common.tensor import ScalingTensor
 from msamp.optim import LBAdamW, LBAdam, LBAdamWBase, DSAdam
 from msamp.nn import LinearReplacer
 from tests.helper import decorator


### PR DESCRIPTION
**Description**
The argument `model_state.use_fp8_ddp` is deprecated.
In MS-AMP examples, all of `model_state.use_fp8_ddp` are set to True. Besides, the function `optimizer.all_reduce_grads` has not been used.

**Major Revision**
- Remove `model_state.use_fp8_ddp`
- Remove `optimizer.all_reduce_grads`
- Remove the related unittests
- Update the unittest `test_fp8linear_backward` since the type of weight gradient is torch.Tensor when `model_state.use_fp8_ddp` is True.
