### PR TITLE
Make new optimizer more extensible, easier to integrate downstream for FSDP

### DIFF
--- a/examples/mnist_fsdp.py
+++ b/examples/mnist_fsdp.py
@@ -9,7 +9,6 @@ It is adapted from https://github.com/pytorch/examples/blob/main/mnist/main.py.
 import os
 import argparse
 import functools
-import msamp
 
 import torch
 import torch.nn as nn
@@ -152,6 +151,7 @@ def fsdp_main(rank, world_size, args):
     
 
     if args.msamp:
+        import msamp
         from msamp.fsdp import FsdpReplacer
         from msamp.fsdp import FP8FullyShardedDataParallel
         model, optimizer = msamp.initialize(model, optimizer)

--- a/msamp/optim/adamw.py
+++ b/msamp/optim/adamw.py
@@ -239,42 +239,10 @@ class FSDPAdamW(MSAMPOptimWrapper):
     """Implements AdamW algorithm for FSDP."""
     def __init__(
         self,
-        params,
-        lr=1e-3,
-        bias_correction=True,
-        betas=(0.9, 0.999),
-        eps=1e-8,
-        weight_decay=1e-2,
-        amsgrad=False,
-        *,
-        maximize: bool = False,
-        exp_avg_dtype=torch.uint8,
-        exp_avg_sq_dtype=torch.float16,
-        tensor_scale=True,
         optimizer=None,
     ):
         """Constructor. See LBAdamW class docstring for details."""
-        if optimizer is not None:
-            super().__init__(optimizer)
-        else:
-            self.tensor_scale = tensor_scale
-            optim = LBAdamW(
-                params,
-                lr=lr,
-                bias_correction=bias_correction,
-                betas=betas,
-                eps=eps,
-                weight_decay=weight_decay,
-                amsgrad=False,
-                maximize=maximize,
-                exp_avg_dtype=exp_avg_dtype,
-                exp_avg_sq_dtype=exp_avg_sq_dtype
-            )
-            super().__init__(optim)
-        self.adjust_param_groups()
-
-
-    def adjust_param_groups(self):
+        super().__init__(optimizer)
         self.original_params = []
         self.master_weights = []
         for group in self.param_groups:

--- a/msamp/optim/adamw.py
+++ b/msamp/optim/adamw.py
@@ -10,7 +10,8 @@ import torch
 from torch import Tensor
 import torch.distributed as dist
 
-from msamp.optim import LBAdamWBase, MSAMPOptimWrapper
+from msamp.optim import LBAdamWBase
+from msamp.optim.optimizer import MSAMPOptimWrapper
 from msamp.common.tensor import ScalingMeta, ScalingTensor
 from msamp.common.dtype import Floating, Dtypes
 import msamp_adamw

--- a/msamp/optim/optimizer.py
+++ b/msamp/optim/optimizer.py
@@ -17,6 +17,51 @@ from msamp.common.tensor import TensorDist
 from msamp.nn import model_state, ScalingParameter
 
 
+class MSAMPOptimWrapper(Optimizer):
+    """
+    A wrapper around an optimizer for easier extensibility.
+    All methods are delegated to the underlying optimizer,
+    so that custom functionality can be added by subclassing this class.
+    """
+    def __init__(self, optimizer):
+        self.optimizer = optimizer
+
+    @property
+    def state(self):
+        return self.optimizer.state
+
+    @state.setter
+    def state(self, state):
+        self.optimizer.state = state
+
+    @property
+    def param_groups(self):
+        return self.optimizer.param_groups
+
+    @property
+    def defaults(self):
+        return self.optimizer.defaults
+
+    @defaults.setter
+    def defaults(self, defaults):
+        self.optimizer.defaults = defaults
+
+    def add_param_group(self, param_group):
+        self.optimizer.add_param_group(param_group)
+
+    def load_state_dict(self, state_dict):
+        self.optimizer.load_state_dict(state_dict)
+
+    def state_dict(self):
+        return self.optimizer.state_dict()
+
+    def zero_grad(self, set_to_none=None):
+        self.optimizer.zero_grad(set_to_none)
+
+    def step(self, **kwargs):
+        return self.optimizer.step(**kwargs)
+
+
 class LBOptimizer(Optimizer):
     """Low-bit optimizer base class.
 


### PR DESCRIPTION
**Description**
This PR makes it easier for users to use FSDP with MS-AMP from their existing optimizers. This is especially beneficial for library authors, as currently we need to go through quite a bit to get the FSDP version of these optimizers working when a user passes in `optim.Adam`. 

Instead we delegate the `FSDPAdamW` to an `OptimWrapper`, which calls an underlying `optimizer` as a passthrough. This lets us add in any logic that should be done before/after said logic easier, and it takes in a constructed `Optimizer` rather than being inherited, so users can still just use one API (`initialize`) rather than needing to do everything manually themselves.

Let me know what we think about this, currently I'm going through integrating FSDP and DeepSpeed w/ MS-AMP into Accelerate and found this to be a critical painpoint, as our users pass in normal PyTorch optimizers and don't create special versions themselves. 

Calling `model = FsdpReplacer.replace(model)` should be fine, since it's a `no-op` relacement followed by the param updating it needs to do. 

@tocean @wkcn let me know what you two think :)