### PR TITLE
remove algolia

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -94,11 +94,6 @@ module.exports = {
         '📢 <a href="https://azure.github.io/MS-AMP/blog/release-msamp-v0.4">v0.4.0</a> has been released! ' +
         '⭐️ If you like MS-AMP, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/Azure/MS-AMP">GitHub</a>! ⭐️',
     },
-    algolia: {
-      apiKey: '6809111d3dabf59fe562601d591d7c53',
-      indexName: 'msamp',
-      contextualSearch: true,
-    },
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,


### PR DESCRIPTION
**Description**
remove algolia apikey to mitigate serv2 ticket. The contextual search does not work now since because we don't config crawler for it. We can temporarily remove it to mitigate urgent serv2 ticket